### PR TITLE
Show encryption only if app is enabled

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,4 +36,8 @@
 		<admin>OCA\Encryption\Panels\Admin</admin>
 		<personal>OCA\Encryption\Panels\Personal</personal>
 	</settings>
+	<settings-sections>
+		<admin>OCA\Encryption\AdminSection</admin>
+		<personal>OCA\Encryption\PersonalSection</personal>
+	</settings-sections>
 </info>

--- a/lib/AdminSection.php
+++ b/lib/AdminSection.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Encryption;
+
+use OCP\IL10N;
+use OCP\Settings\ISection;
+
+class AdminSection implements ISection {
+	protected $l;
+
+	public function __construct(IL10N $l) {
+		$this->l = $l;
+	}
+
+	public function getPriority() {
+		return 85;
+	}
+
+	public function getIconName() {
+		return 'password';
+	}
+
+	public function getID() {
+		return 'encryption';
+	}
+
+	public function getName() {
+		return $this->l->t('Encryption');
+	}
+}
+

--- a/lib/PersonalSection.php
+++ b/lib/PersonalSection.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption;
+
+use OCP\IL10N;
+use OCP\Settings\ISection;
+
+class PersonalSection implements ISection {
+	protected $l;
+
+	public function __construct(IL10N $l) {
+		$this->l = $l;
+	}
+
+	public function getPriority() {
+		return 20;
+	}
+
+	public function getIconName() {
+		return 'password';
+	}
+
+	public function getID() {
+		return 'encryption';
+	}
+
+	public function getName() {
+		return $this->l->t('Encryption');
+	}
+}


### PR DESCRIPTION
Show encryption in the settings panel
both personal and admin only if the app
is enabled.

Signed-off-by: Sujith H <sharidasan@owncloud.com>