### PR TITLE
Cleanup alternate storage location keys of user

### DIFF
--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -198,8 +198,16 @@ class UserHooks implements IHook {
 	public function postDeleteUser($params) {
 
 		if (App::isEnabled('encryption')) {
-			$this->keyManager->deletePublicKey($params['uid']);
+			/**
+			 * Adding a safe condition to make sure the uid is not
+			 * empty or null.
+			 */
+			if (!is_null($params['uid']) && ($params['uid'] !== '')) {
+				$this->keyManager->deletePublicKey($params['uid']);
+				\OC::$server->getEncryptionKeyStorage()->deleteAltUserStorageKeys($params['uid']);
+			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
This is to make sure that there are no user
specific folders if the keys are stored in
alternate location apart from the default
location, when a user is deleted. Hence the
keys inside user folder in the alternate
location would be deleted.

Signed-off-by: Sujith H <sharidasan@owncloud.com>