### PR TITLE
Fix the missing argument to DecryptAll

### DIFF
--- a/lib/Command/RecreateMasterKey.php
+++ b/lib/Command/RecreateMasterKey.php
@@ -240,7 +240,7 @@ class RecreateMasterKey extends Command {
 	}
 
 	protected function decryptAllUsers(InputInterface $input, OutputInterface $output) {
-		$this->decryptAll = new DecryptAll($this->encryptionManager, $this->userManager, $this->rootView);
+		$this->decryptAll = new DecryptAll($this->encryptionManager, $this->userManager, $this->rootView, $this->logger);
 		$this->decryptAll->decryptAll($input,$output);
 	}
 


### PR DESCRIPTION
logger is the last argument to DecryptAll which
was missing when DecryptAll is called. This change
fixes the same.

Signed-off-by: Sujith H <sharidasan@owncloud.com>