### PR TITLE
Add re-login information after successful action

### DIFF
--- a/lib/Command/RecreateMasterKey.php
+++ b/lib/Command/RecreateMasterKey.php
@@ -226,6 +226,7 @@ class RecreateMasterKey extends Command {
 				$this->keyManager->validateMasterKey();
 				$this->encryptAllUsers($input, $output);
 				$output->writeln("\nEncryption completed successfully\n");
+				$output->writeln("\n<info>Note: All users are required to relogin.</info>\n");
 			} else {
 				$output->writeln("The process is abandoned");
 			}

--- a/tests/unit/Command/RecreateMasterKeyTest.php
+++ b/tests/unit/Command/RecreateMasterKeyTest.php
@@ -193,17 +193,24 @@ class RecreateMasterKeyTest extends TestCase {
 				->with('user1')
 				->willReturn(true);
 
-			global $outputText;
+			$outputText = '';
+			$reloginText = '';
 
 			$this->output->expects($this->at(16))
 				->method('writeln')
-				->willReturnCallback(function ($value) {
-					global $outputText;
+				->willReturnCallback(function ($value) use (&$outputText) {
 					$outputText .= $value . "\n";
+				});
+
+			$this->output->expects($this->at(17))
+				->method('writeln')
+				->willReturnCallback(function ($value) use (&$reloginText) {
+					$reloginText = $value;
 				});
 
 			$this->invokePrivate($this->recreateMasterKey, 'execute', [$this->input, $this->output]);
 			$this->assertSame("Encryption completed successfully", \trim($outputText, "\n"));
+			$this->assertEquals("\n<info>Note: All users are required to relogin.</info>\n", $reloginText);
 			$outputText="";
 		} else {
 			$this->recreateMasterKey = $this->getMockBuilder('OCA\Encryption\Command\RecreateMasterKey')


### PR DESCRIPTION
After the command is executed successfully by
recreating masterkey, the user should be informed
to relogin.

Signed-off-by: Sujith H <sharidasan@owncloud.com>