### PR TITLE
Clear text when recovery key is disabled

### DIFF
--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -103,6 +103,8 @@ $(document).ready(function () {
 					$('p[name="changeRecoveryPasswordBlock"]').addClass("hidden");
 					$('input:button[name="enableRecoveryKey"]').attr('value', 'Enable recovery key');
 					$('input:button[name="enableRecoveryKey"]').attr('status', '0');
+					$("#encryptionRecoveryPassword").val("");
+					$("#repeatEncryptionRecoveryPassword").val("");
 				} else {
 					$('input:password[name="changeRecoveryPassword"]').val("");
 					$('p[name="changeRecoveryPasswordBlock"]').removeClass("hidden");


### PR DESCRIPTION
When recovery key is disabled after enabled
earlier, the password texts are cleared.

Signed-off-by: Sujith H <sharidasan@owncloud.com>