### PR TITLE
Use '.part' name appended to the file name for encryptall

### DIFF
--- a/lib/Crypto/EncryptAll.php
+++ b/lib/Crypto/EncryptAll.php
@@ -265,6 +265,10 @@ class EncryptAll {
 		while ($root = array_pop($directories)) {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
+				// only encrypt files owned by the user, exclude incoming local shares, and incoming federated shares
+				if ($file->getStorage()->instanceOfStorage('\OCA\Files_Sharing\ISharedStorage')) {
+					continue;
+				}
 				$path = $root . '/' . $file['name'];
 				if ($this->rootView->is_dir($path)) {
 					$directories[] = $path;
@@ -290,7 +294,7 @@ class EncryptAll {
 	protected function encryptFile($path) {
 
 		$source = $path;
-		$target = $path . '.encrypted.' . time();
+		$target = $path . '.encrypted.' . time() . '.part';
 
 		try {
 			$this->keyManager->setVersion($source, 0, $this->rootView);


### PR DESCRIPTION
When dealing with copy and rename operation in
encryptall, its better to use '.part' appended
to the file name.

Signed-off-by: Sujith H <sharidasan@owncloud.com>