### PR TITLE
Enable user-keys if no encryption mode is enabled during login

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -94,7 +94,7 @@ class Application extends \OCP\AppFramework\App {
 					$container->query('Util'),
 					$container->query('Session'),
 					$container->query('Crypt'),
-					$container->query('Recovery'))
+					$container->query('Recovery'), $server->getConfig())
 			]);
 
 			$hookManager->fireHooks();

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -26,6 +26,7 @@ namespace OCA\Encryption\Hooks;
 
 
 use OC\Files\Filesystem;
+use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Util as OCUtil;
 use OCA\Encryption\Hooks\Contracts\IHook;
@@ -76,6 +77,10 @@ class UserHooks implements IHook {
 	 * @var Crypt
 	 */
 	private $crypt;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
 
 	/**
 	 * UserHooks constructor.
@@ -89,6 +94,7 @@ class UserHooks implements IHook {
 	 * @param Session $session
 	 * @param Crypt $crypt
 	 * @param Recovery $recovery
+	 * @param IConfig $config
 	 */
 	public function __construct(KeyManager $keyManager,
 								IUserManager $userManager,
@@ -98,7 +104,7 @@ class UserHooks implements IHook {
 								Util $util,
 								Session $session,
 								Crypt $crypt,
-								Recovery $recovery) {
+								Recovery $recovery, IConfig $config) {
 
 		$this->keyManager = $keyManager;
 		$this->userManager = $userManager;
@@ -109,6 +115,7 @@ class UserHooks implements IHook {
 		$this->session = $session;
 		$this->recovery = $recovery;
 		$this->crypt = $crypt;
+		$this->config = $config;
 	}
 
 	/**
@@ -164,6 +171,11 @@ class UserHooks implements IHook {
 		}
 		if ($this->util->isMasterKeyEnabled() === false) {
 			$this->userSetup->setupUser($params['uid'], $params['password']);
+		}
+
+		if (($this->util->isMasterKeyEnabled() === false) &&
+			($this->config->getAppValue('encryption', 'userSpecificKey', '') === '')) {
+			$this->config->setAppValue('encryption', 'userSpecificKey', '1');
 		}
 
 		$this->keyManager->init($params['uid'], $params['password']);

--- a/tests/Hooks/UserHooksTest.php
+++ b/tests/Hooks/UserHooksTest.php
@@ -30,6 +30,8 @@ namespace OCA\Encryption\Tests\Hooks;
 
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Hooks\UserHooks;
+use OCA\Encryption\Util;
+use OCP\IConfig;
 use Test\TestCase;
 
 /**
@@ -76,6 +78,7 @@ class UserHooksTest extends TestCase {
 	 * @var \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $loggerMock;
+	private $config;
 	/**
 	 * @var UserHooks
 	 */
@@ -91,6 +94,12 @@ class UserHooksTest extends TestCase {
 		$this->keyManagerMock->expects($this->once())
 			->method('init')
 			->with('testUser', 'password');
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturnMap([
+				['encryption', 'userSpecificKey', '', ''],
+			]);
 
 		$this->assertNull($this->instance->login($this->params));
 	}
@@ -136,7 +145,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)
 			->setMethods(['setPassphrase'])
@@ -215,7 +225,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['initMountPoints'])->getMock();
 
@@ -278,7 +289,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['initMountPoints'])->getMock();
 
@@ -331,9 +343,9 @@ class UserHooksTest extends TestCase {
 			->method($this->anything())
 			->will($this->returnSelf());
 
-		$utilMock = $this->getMockBuilder('OCA\Encryption\Util')
+		/*$utilMock = $this->getMockBuilder('OCA\Encryption\Util')
 			->disableOriginalConstructor()
-			->getMock();
+			->getMock();*/
 
 		$sessionMock = $this->getMockBuilder('OCA\Encryption\Session')
 			->disableOriginalConstructor()
@@ -345,10 +357,11 @@ class UserHooksTest extends TestCase {
 		$recoveryMock = $this->getMockBuilder('OCA\Encryption\Recovery')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->sessionMock = $sessionMock;
 		$this->recoveryMock = $recoveryMock;
-		$this->utilMock = $utilMock;
+		$this->utilMock = $this->createMock(Util::class);
 		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
 		$this->instance = $this->getMockBuilder('OCA\Encryption\Hooks\UserHooks')
@@ -362,7 +375,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['setupFS'])->getMock();
 


### PR DESCRIPTION
Enable user-keys if no encryption mode is enabled
during user login.

Signed-off-by: Sujith H <sharidasan@owncloud.com>