### PR TITLE
Fix login exception in decryptall

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -259,6 +259,7 @@ class Application extends \OCP\AppFramework\App {
 					$c->query('KeyManager'),
 					$c->query('Crypt'),
 					$c->query('Session'),
+					$c->getServer()->getUserManager(),
 					new QuestionHelper()
 				);
 			}


### PR DESCRIPTION
When the decryptall is called with user-keys
enabled, make sure the password provided by
user is correct else throw exception.

Signed-off-by: Sujith H <sharidasan@owncloud.com>