### PR TITLE
Fix user-keys encryption when user created with email

### DIFF
--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -246,10 +246,14 @@ class UserHooks implements IHook {
 	 * @return boolean|null
 	 */
 	public function setPassphrase($params) {
-
-		// Get existing decrypted private key
-		$privateKey = $this->session->getPrivateKey();
-		$user = $this->user->getUser();
+		$privateKey = null;
+		$user = null;
+		//Check if a session is there or not
+		if ($this->user->getUser() !== null) {
+			// Get existing decrypted private key
+			$privateKey = $this->session->getPrivateKey();
+			$user = $this->user->getUser();
+		}
 
 		// current logged in user changes his own password
 		if ($user && $params['uid'] === $user->getUID() && $privateKey) {

--- a/tests/Hooks/UserHooksTest.php
+++ b/tests/Hooks/UserHooksTest.php
@@ -28,10 +28,17 @@
 namespace OCA\Encryption\Tests\Hooks;
 
 
+use OC\User\Manager;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Hooks\UserHooks;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Recovery;
+use OCA\Encryption\Session;
+use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IUserSession;
 use Test\TestCase;
 
 /**
@@ -262,8 +269,86 @@ class UserHooksTest extends TestCase {
 		$this->assertNull($this->instance->setPassphrase($this->params));
 	}
 
+	/**
+	 * Test setPassphrase without session and no logger error should appear
+	 */
+	public function testSetPassphraseWithoutSession() {
+		$keyManager = $this->createMock(KeyManager::class);
+		$userManager = $this->createMock(Manager::class);
+		$logger = $this->createMock(ILogger::class);
+		$setUp = $this->createMock(Setup::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$encryptionUtil = $this->createMock(Util::class);
+		$encryptionSession = $this->createMock(Session::class);
+		$recovery = $this->createMock(Recovery::class);
+		$crypt = $this->createMock(Crypt::class);
+		$config = $this->createMock(IConfig::class);
+
+		//$userHooks = new UserHooks($keyManager, $userManager, $logger, $setUp, $userSession, $encryptionUtil, $encryptionSession, $crypt, $recovery, $config);
+		$userHooks = $this->getMockBuilder(UserHooks::class)
+			->setConstructorArgs([
+				$keyManager, $userManager, $logger,
+				$setUp, $userSession, $encryptionUtil,
+				$encryptionSession, $crypt, $recovery, $config
+			])->setMethods(['initMountPoints'])->getMock();
+
+		$userSession->expects($this->any())
+			->method('getUser')
+			->willReturn(null);
+
+		$crypt->expects($this->any())
+			->method('encryptPrivateKey')
+			->willReturn(true);
+
+		$keyManager->expects($this->any())
+			->method('setPrivateKey')
+			->willReturn(true);
+
+		//No logger error should appear
+		$logger->expects($this->never())
+			->method('error');
+
+		$userHooks->setPassphrase($this->params);
+	}
+
+	public function testSetPassphraseWithoutSessionLoggerError() {
+		$keyManager = $this->createMock(KeyManager::class);
+		$userManager = $this->createMock(Manager::class);
+		$logger = $this->createMock(ILogger::class);
+		$setUp = $this->createMock(Setup::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$encryptionUtil = $this->createMock(Util::class);
+		$encryptionSession = $this->createMock(Session::class);
+		$recovery = $this->createMock(Recovery::class);
+		$crypt = $this->createMock(Crypt::class);
+		$config = $this->createMock(IConfig::class);
+
+		//$userHooks = new UserHooks($keyManager, $userManager, $logger, $setUp, $userSession, $encryptionUtil, $encryptionSession, $crypt, $recovery, $config);
+		$userHooks = $this->getMockBuilder(UserHooks::class)
+			->setConstructorArgs([
+				$keyManager, $userManager, $logger,
+				$setUp, $userSession, $encryptionUtil,
+				$encryptionSession, $crypt, $recovery, $config
+			])->setMethods(['initMountPoints'])->getMock();
+
+		$userSession->expects($this->any())
+			->method('getUser')
+			->willReturn(null);
+
+		$crypt->expects($this->any())
+			->method('encryptPrivateKey')
+			->willReturn(false);
+
+		//No logger error should appear
+		$logger->expects($this->any())
+			->method('error')
+			->with('Encryption Could not update users encryption password');
+
+		$userHooks->setPassphrase($this->params);
+	}
+
 	public function testSetPasswordNoUser() {
-		$this->sessionMock->expects($this->once())
+		$this->sessionMock->expects($this->any())
 			->method('getPrivateKey')
 			->willReturn(true);
 


### PR DESCRIPTION
When user tries to set the password without logging
in for once and no session available, the user-keys
encryption was failing to create the private key
for the new password. This change helps to fix the
issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>