### PR TITLE
adjust acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
@@ -79,7 +79,7 @@ class AdminEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -87,7 +87,7 @@ class AdminEncryptionSettingsPage extends OwncloudPage {
 			if ($this->findById($this->enableEncryptionCheckboxId) !== null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 

--- a/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
@@ -68,7 +68,7 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -76,7 +76,7 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 			if ($this->findById($this->userEnableRecoveryCheckboxId) !== null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 


### PR DESCRIPTION
Old forms of the constant names were deprecated by https://github.com/owncloud/core/pull/32781/commits/db4608ace28ed62a00173021416951fb7ac3d994

Use the new forms that have underscores.