### PR TITLE
Run cli acceptance tests for pgsql and PHP 7.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -368,21 +368,21 @@ matrix:
       OC_VERSION: daily-master-qa
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
-      TEST_SUITE: api
+      TEST_SUITE: cli
       ENCRYPTION_TYPE: masterkey
       DB_TYPE: pgsql
       DB_HOST: pgsql
-      TEST_SOURCE: encryption
+      TEST_SOURCE: cli-encryption
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
       PREPARE_ACCEPTANCE: true
       USE_SERVER: true
-      TEST_SUITE: api
+      TEST_SUITE: cli
       ENCRYPTION_TYPE: masterkey
       DB_TYPE: mysql
       DB_HOST: mysql
-      TEST_SOURCE: encryption
+      TEST_SOURCE: cli-encryption
 
     ## UI core stable10 with masterkey encryption
     - PHP_VERSION: 5.6


### PR DESCRIPTION
``TEST_SOURCE: encryption`` was a NOOP - there is no pipeline step that matches it. The 2 matrix entries here were just doing all the setup and then exiting "happy". Actually there are no specific ``api`` acceptance tests in the encryption app.

Change these matrix entries so they run the ``cli`` acceptance tests, like the matrix entry above them.