### PR TITLE
Use unique usernames in unit tests

### DIFF
--- a/tests/unit/Crypto/DecryptAllTest.php
+++ b/tests/unit/Crypto/DecryptAllTest.php
@@ -201,7 +201,8 @@ class DecryptAllTest extends TestCase {
 	 * @expectedExceptionMessage Invalid credentials provided
 	 */
 	public function testPrepareLoginException($loginType) {
-		$this->createUser('user1', 'pass');
+		$username = "decrypt_test_user1_";
+		$this->createUser($username, 'pass');
 		$input = $this->createMock(InputInterface::class);
 		$output = $this->createMock(OutputInterface::class);
 

--- a/tests/unit/Crypto/EncryptAllTest.php
+++ b/tests/unit/Crypto/EncryptAllTest.php
@@ -389,10 +389,12 @@ class EncryptAllTest extends TestCase {
 	}
 
 	public function testEncryptFileFileId() {
-		$this->createUser('user1', 'user1');
-		\OC::$server->getUserFolder('user1');
+		$userName = $this->getUniqueID('encrypt_test_user1_');
 
-		$view = new View('/user1/files');
+		$this->createUser($userName, 'user1');
+		\OC::$server->getUserFolder($userName);
+
+		$view = new View("/{$userName}/files");
 		$view->touch('bar.txt');
 		$oldFileInfo = $view->getFileInfo('bar.txt');
 
@@ -415,11 +417,11 @@ class EncryptAllTest extends TestCase {
 			->setMethods(['setupUserFS'])
 			->getMock();
 
-		$result = $this->invokePrivate($encryptAll, 'encryptFile', ['/user1/files/bar.txt']);
+		$result = $this->invokePrivate($encryptAll, 'encryptFile', ["/${userName}/files/bar.txt"]);
 		$this->assertTrue($result);
 
 		$view1 = new View('/');
-		$fileInfo = $view1->getFileInfo('/user1/files/bar.txt');
+		$fileInfo = $view1->getFileInfo("/{$userName}/files/bar.txt");
 		$this->assertEquals($fileInfo->getId(), $oldFileInfo->getId());
 	}
 


### PR DESCRIPTION
Use unique usernames in unit tests.

Signed-off-by: Sujith H <sharidasan@owncloud.com>