### PR TITLE
use bootstrap.php of core acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -19,8 +19,8 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-require __DIR__ . '/../../../../../../lib/base.php';
-require __DIR__ . '/../../../../../../lib/composer/autoload.php';
+
+require_once __DIR__ . '/../../../../../../tests/acceptance/features/bootstrap/bootstrap.php';
 
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4(
@@ -29,9 +29,6 @@ $classLoader->addPsr4(
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 $classLoader->addPsr4(
 	"Page\\", __DIR__ . "/../../../../../../tests/acceptance/features/lib", true
-);
-$classLoader->addPsr4(
-	"TestHelpers\\", __DIR__ . "/../../../../../../tests/TestHelpers", true
 );
 
 $classLoader->register();


### PR DESCRIPTION
## Description
use the `bootstrap.php` from core

## Related Issue
https://github.com/owncloud/QA/issues/605

## Motivation and Context
Run accepectance tests through make command.
e.g: 
`make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/cliEncryption/recreatemasterkey.feature TESTING_REMOTE_SYSTEM=true  NORERUN=true TEST_SERVER_URL=http://172.17.0.1/owncloud-core`

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

