### PR TITLE
Run all 15 parts of core webUI test suites

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -653,6 +653,51 @@ matrix:
       TEST_SUITE: core-web-acceptance
       PART: 12
 
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SERVER: true
+      NEED_SELENIUM: true
+      NEED_EMAIL: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      ENCRYPTION_TYPE: masterkey
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      TEST_SUITE: core-web-acceptance
+      PART: 13
+
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SERVER: true
+      NEED_SELENIUM: true
+      NEED_EMAIL: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      ENCRYPTION_TYPE: masterkey
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      TEST_SUITE: core-web-acceptance
+      PART: 14
+
+    - PHP_VERSION: 5.6
+      OC_VERSION: daily-stable10-qa
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SERVER: true
+      NEED_SELENIUM: true
+      NEED_EMAIL: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      ENCRYPTION_TYPE: masterkey
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      TEST_SUITE: core-web-acceptance
+      PART: 15
+
     ## UI core stable10 with user-keys encryption
     - PHP_VERSION: 5.6
       OC_VERSION: daily-stable10-qa


### PR DESCRIPTION
The UI core stable10 with masterkey encryption drone matrix section was only running 12 of 15 parts of the core webUI test suites. Matrix jobs for parts 13,14,15 were missed.

I noticed this while comparing drone here with user_ldap and files_primary_s3 that also do this sort of thing.