### PR TITLE
Refactor running core acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -218,10 +218,9 @@ pipeline:
       - DIVIDE_INTO_NUM_PARTS=15
       - RUN_PART=${PART}
     commands:
-      - cd /var/www/owncloud/tests/acceptance/
       - touch /var/www/owncloud/saved-settings.sh
       - . /var/www/owncloud/saved-settings.sh
-      - su-exec www-data ./run.sh --remote --type webUI --tags '~@skipOnEncryption&&~@skipOnEncryptionType:${ENCRYPTION_TYPE}&&~@skip'
+      - make test-acceptance-core-webui
     when:
       matrix:
         TEST_SUITE: core-web-acceptance
@@ -235,10 +234,9 @@ pipeline:
       - DIVIDE_INTO_NUM_PARTS=15
       - RUN_PART=${PART}
     commands:
-      - cd /var/www/owncloud/tests/acceptance/
       - touch /var/www/owncloud/saved-settings.sh
       - . /var/www/owncloud/saved-settings.sh
-      - su-exec www-data ./run.sh --remote --type api --tags '~@skipOnEncryption&&~@skipOnEncryptionType:${ENCRYPTION_TYPE}&&~@skip'
+      - make test-acceptance-core-api
     when:
       matrix:
         TEST_SUITE: core-api-acceptance

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test-php-phpstan: vendor-bin/phpstan/vendor
 	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 
 .PHONY: test-acceptance-api
-test-acceptance-api: ## Run php-cs-fixer and fix code style issues
+test-acceptance-api: ## Run API acceptance tests
 test-acceptance-api: vendor
 	../../tests/acceptance/run.sh --remote --type api
 
@@ -98,6 +98,16 @@ test-acceptance-cli: vendor
 test-acceptance-webui: ## Run webUI acceptance tests
 test-acceptance-webui: vendor
 	../../tests/acceptance/run.sh --remote --type webUI
+
+.PHONY: test-acceptance-core-api
+test-acceptance-core-api: ## Run core API acceptance tests
+test-acceptance-core-api: vendor
+	../../tests/acceptance/run.sh --remote --type api -c ../../tests/acceptance/config/behat.yml --tags '~@skipOnEncryption&&~@skipOnEncryptionType:${ENCRYPTION_TYPE}&&~@skip'
+
+.PHONY: test-acceptance-core-webui
+test-acceptance-core-webui: ## Run core webUI acceptance tests
+test-acceptance-core-webui: vendor
+	../../tests/acceptance/run.sh --remote --type webui -c ../../tests/acceptance/config/behat.yml --tags '~@skipOnEncryption&&~@skipOnEncryptionType:${ENCRYPTION_TYPE}&&~@skip'
 
 #
 # Dependency management


### PR DESCRIPTION
1) push the "gory" details of the ``run.sh`` command for running core acceptance tests down from drone to ``Makefile``
2) In the ``run.sh`` command specify how to find the core Behat config, and what combination of tags to select. That will make hose things "fixed" for anyone who calls the ``Makefile`` target.
3) Leave the control of how many parts (jobs) to parallel ( ``DIVIDE_INTO_NUM_PARTS`` and ``RUN_PART`` ) in drone. That is a performance/elapsed time thing that we are controlling for drone. If someone else wants to ``make test-acceptance-core-api`` or ``make test-acceptance-core-webui`` then they will need to decide for themselves if they are running all test scenarios matching the tags (hours of run time), or defining a "part" to run, or they might want to define ``BEHAT_SUITE`` to run 1 suite at a time, or some other way to select a manageable subset of test scenarios to run.