### PR TITLE
Use owncloud-coding-standard for PHP lint syntax checks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,6 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - ../../lib/composer/bin/parallel-lint . --exclude 3rdparty --exclude build .
       - cd /var/www/owncloud
       #- php ./occ app:check-code encryption -c private -c strong-comparison
       - php ./occ app:check-code encryption -c deprecation
@@ -322,6 +321,12 @@ matrix:
   include:
     # owncloud-coding-standard
     - PHP_VERSION: 7.1
+      TEST_SUITE: owncloud-coding-standard
+
+    - PHP_VERSION: 7.2
+      TEST_SUITE: owncloud-coding-standard
+
+    - PHP_VERSION: 7.3
       TEST_SUITE: owncloud-coding-standard
 
     # Unit Tests

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ all_src=$(src_dirs) $(doc_files)
 # bin file definitions
 PHPUNIT=php -d zend.enable_gc=0 ../../lib/composer/bin/phpunit
 PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "../../lib/composer/bin/phpunit"
-PHPLINT=php -d zend.enable_gc=0  vendor-bin/php-parallel-lint/vendor/bin/parallel-lint
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
 PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
 PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
@@ -58,11 +57,6 @@ test-php-unit: ../../lib/composer/bin/phpunit
 test-php-unit-dbg: ## Run php unit tests using phpdbg
 test-php-unit-dbg: ../../lib/composer/bin/phpunit
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
-
-.PHONY: test-php-lint
-test-php-lint: ## Run phan
-test-php-lint: vendor-bin/php-parallel-lint/vendor
-	$(PHPLINT) appinfo lib
 
 .PHONY: test-php-style
 test-php-style: ## Run php-cs-fixer and check owncloud code-style
@@ -121,12 +115,6 @@ vendor:
 
 vendor/bamarni/composer-bin-plugin:
 	composer install
-
-vendor-bin/php-parallel-lint/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/php-parallel-lint/composer.lock
-	composer bin php-parallel-lint install --no-progress
-
-vendor-bin/php-parallel-lint/composer.lock: vendor-bin/php-parallel-lint/composer.json
-	@echo php-parallel-lint composer.lock is not up to date.
 
 vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
 	composer bin owncloud-codestyle install --no-progress


### PR DESCRIPTION
We are using owncloud-coding-standard to effectively provide PHP syntax (lint) checks these days.
So remove ``lint`` from here, and run owncloud-coding-standard for each PHP version.

Note: ``encryption`` app is currently for use with core ``master`` and so only needs PHP 7.1 and later.