### PR TITLE
do not trim content of downloaded file

### DIFF
--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -125,7 +125,7 @@ class EncryptionContext implements Context {
 		$fileContentServer = (string)$this->featureContext->getResponse()->getBody();
 
 		PHPUnit_Framework_Assert::assertEquals(
-			\trim($fileContentServer),
+			$fileContentServer,
 			$fileContent
 		);
 	}


### PR DESCRIPTION
the testing app does not trim the content any more (see owncloud/testing#90), so we don't want to trim it on the receiver side