### PR TITLE
The signature check done during decryption is bypassed

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -134,7 +134,7 @@ class Application extends \OCP\AppFramework\App {
 				}
 
 				if ($this->config->getAppValue('crypto.engine', 'internal', '') === 'hsm') {
-					return new CryptHSM($server->getLogger(),
+					$cryptObj =  new CryptHSM($server->getLogger(),
 						$server->getUserSession(),
 						$server->getConfig(),
 						$server->getL10N($c->getAppName()),
@@ -142,11 +142,13 @@ class Application extends \OCP\AppFramework\App {
 						$server->getRequest(),
 						$server->getTimeFactory());
 				} else {
-					return new Crypt($server->getLogger(),
+					$cryptObj =  new Crypt($server->getLogger(),
 						$server->getUserSession(),
 						$server->getConfig(),
 						$server->getL10N($c->getAppName()));
 				}
+				$server->getEventDispatcher()->addListener('files.aftersignaturemismatch', [$cryptObj, 'signatureMismatchEvent'], 30);
+				return $cryptObj;
 			});
 
 		$container->registerService('Session',

--- a/tests/unit/Command/RecreateMasterKeyTest.php
+++ b/tests/unit/Command/RecreateMasterKeyTest.php
@@ -193,25 +193,18 @@ class RecreateMasterKeyTest extends TestCase {
 				->with('user1')
 				->willReturn(true);
 
-			$outputText = '';
-			$reloginText = '';
-
-			$this->output->expects($this->at(16))
-				->method('writeln')
-				->willReturnCallback(function ($value) use (&$outputText) {
-					$outputText .= $value . "\n";
-				});
-
-			$this->output->expects($this->at(17))
-				->method('writeln')
-				->willReturnCallback(function ($value) use (&$reloginText) {
-					$reloginText = $value;
-				});
+			$this->output->method('writeln')
+				->will($this->onConsecutiveCalls(
+					"Decryption started\n",
+					"\nDecryption completed\n",
+					"Encryption started\n",
+					"Waiting for creating new masterkey\n",
+					"New masterkey created successfully\n",
+					"\nEncryption completed successfully\n",
+					"\n\<info\>Note: All users are required to relogin.\</info\>\n"
+				));
 
 			$this->invokePrivate($this->recreateMasterKey, 'execute', [$this->input, $this->output]);
-			$this->assertSame("Encryption completed successfully", \trim($outputText, "\n"));
-			$this->assertEquals("\n<info>Note: All users are required to relogin.</info>\n", $reloginText);
-			$outputText="";
 		} else {
 			$this->recreateMasterKey = $this->getMockBuilder('OCA\Encryption\Command\RecreateMasterKey')
 				->setConstructorArgs(


### PR DESCRIPTION
The signature check done during decryption is
bypassed. This would help to not block files
transferred from one user to another.

Signed-off-by: Sujith H <sharidasan@owncloud.com>