### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@
 	<use-migrations>true</use-migrations>
 	<dependencies>
 		<lib>openssl</lib>
-		<owncloud min-version="10.0" max-version="11.0" />
+		<owncloud min-version="10.2" max-version="11.0" />
 	</dependencies>
 	<commands>
 		<command>OCA\Encryption\Command\SelectEncryptionType</command>

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.

Note: the root `composer.json` in this repo already says PHP 7.1 - so we can do that for `behat` also.

If someone some day wants to backport this separated repo stuff to be in core `stable10` (before core `stable10` has dropped PHP 7.0 support) then they anyway have to sort out retrofitting PHP 7.0 support.