### PR TITLE
Sync test code from core

### DIFF
--- a/tests/acceptance/features/cliEncryption/recreatemasterkey.feature
+++ b/tests/acceptance/features/cliEncryption/recreatemasterkey.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @skip_on_objectstore @encryption
 Feature: recreate-master-key
 
 	Scenario: recreate masterkey

--- a/tests/acceptance/features/webUIUserKeysType/userKeys.feature
+++ b/tests/acceptance/features/webUIUserKeysType/userKeys.feature
@@ -1,4 +1,4 @@
-@webUI @skipOnEncryptionType:masterkey
+@webUI @skipOnEncryptionType:masterkey @skipOnStorage:ceph
 Feature: encrypt files using user specific keys
   As an admin
   I want to be able to encrypt user files using user specific keys
@@ -7,8 +7,8 @@ Feature: encrypt files using user specific keys
   Background:
     Given app "encryption" has been enabled
     And these users have been created but not initialized:
-      | username         |
-      | brand-new-user   |
+      | username       |
+      | brand-new-user |
     And encryption has been enabled
 
   @issue-33


### PR DESCRIPTION
Apply a couple of minor differences that are in core `stable10`
Having the matching tags will not hurt anything, and will get rid of the annoying line when doing diffs.

See core PR https://github.com/owncloud/core/pull/34770 for code going the other way