### PR TITLE
Add asserts to tests/unit/Hooks/UserHooksTest.php

### DIFF
--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -128,8 +128,7 @@ class UserHooksTest extends TestCase {
 			->method('deletePublicKey')
 			->with('testUser');
 
-		$this->instance->postDeleteUser($this->params);
-		$this->assertTrue(true);
+		$this->assertNull($this->instance->postDeleteUser($this->params));
 	}
 
 	/**
@@ -177,7 +176,7 @@ class UserHooksTest extends TestCase {
 				->with($this->params);
 		}
 
-		$instance->preSetPassphrase($this->params);
+		$this->assertNull($instance->preSetPassphrase($this->params));
 	}
 
 	public function dataTestPreSetPassphrase() {
@@ -304,7 +303,7 @@ class UserHooksTest extends TestCase {
 		$logger->expects($this->never())
 			->method('error');
 
-		$userHooks->setPassphrase($this->params);
+		$this->assertNull($userHooks->setPassphrase($this->params));
 	}
 
 	public function testSetPassphraseWithoutSessionLoggerError() {
@@ -340,7 +339,7 @@ class UserHooksTest extends TestCase {
 			->method('error')
 			->with('Encryption Could not update users encryption password');
 
-		$userHooks->setPassphrase($this->params);
+		$this->assertNull($userHooks->setPassphrase($this->params));
 	}
 
 	public function testSetPasswordNoUser() {
@@ -388,8 +387,7 @@ class UserHooksTest extends TestCase {
 			->method('setupUser')
 			->with('testUser', 'password');
 
-		$this->instance->postPasswordReset($this->params);
-		$this->assertTrue(true);
+		$this->assertNull($this->instance->postPasswordReset($this->params));
 	}
 
 	protected function setUp() {


### PR DESCRIPTION
To avoid "risky test" warnings like:
https://drone.owncloud.com/owncloud/encryption/590/160
```
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHPDBG 7.1.27-1+ubuntu16.04.1+deb.sury.org+1
Configuration: /var/www/owncloud/server/apps/encryption/phpunit.xml

...............................................................  63 / 238 ( 26%)
............................................................... 126 / 238 ( 52%)
............R.................................................. 189 / 238 ( 79%)
.................................................               238 / 238 (100%)

Time: 8.08 seconds, Memory: 486.00MB

There was 1 risky test:

1) OCA\Encryption\Tests\Hooks\UserHooksTest::testSetPassphraseWithoutSessionLoggerError
This test did not perform any assertions

OK, but incomplete, skipped, or risky tests!
Tests: 238, Assertions: 697, Risky: 1.
```
