### PR TITLE
Enable failOnRisky for phpunit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit bootstrap="tests/unit/bootstrap.php"
 		 strict="true"
 		 verbose="true"
+		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"

--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -128,8 +128,7 @@ class UserHooksTest extends TestCase {
 			->method('deletePublicKey')
 			->with('testUser');
 
-		$this->instance->postDeleteUser($this->params);
-		$this->assertTrue(true);
+		$this->assertNull($this->instance->postDeleteUser($this->params));
 	}
 
 	/**
@@ -177,7 +176,7 @@ class UserHooksTest extends TestCase {
 				->with($this->params);
 		}
 
-		$instance->preSetPassphrase($this->params);
+		$this->assertNull($instance->preSetPassphrase($this->params));
 	}
 
 	public function dataTestPreSetPassphrase() {
@@ -304,7 +303,7 @@ class UserHooksTest extends TestCase {
 		$logger->expects($this->never())
 			->method('error');
 
-		$userHooks->setPassphrase($this->params);
+		$this->assertNull($userHooks->setPassphrase($this->params));
 	}
 
 	public function testSetPassphraseWithoutSessionLoggerError() {
@@ -340,7 +339,7 @@ class UserHooksTest extends TestCase {
 			->method('error')
 			->with('Encryption Could not update users encryption password');
 
-		$userHooks->setPassphrase($this->params);
+		$this->assertNull($userHooks->setPassphrase($this->params));
 	}
 
 	public function testSetPasswordNoUser() {
@@ -388,8 +387,7 @@ class UserHooksTest extends TestCase {
 			->method('setupUser')
 			->with('testUser', 'password');
 
-		$this->instance->postPasswordReset($this->params);
-		$this->assertTrue(true);
+		$this->assertNull($this->instance->postPasswordReset($this->params));
 	}
 
 	protected function setUp() {


### PR DESCRIPTION
These days `phpunit` warns about "risky" tests, like ones that do not make any assertions. For example, these can be tests that check that something "works" - the real method call does not throw an exception. And if the real method call "returns void" on success, then there is nothing much to assert. phpunit will already "built in by default" "assert" that no exception happens.

It is nice to know about such unit tests. Then examine what they do.
1) If they are actually snake oil, then fix them up so that they test something real; or
2) If they really just have to expect that the method "returns void" and no exception is thrown, then wrap the method call in `assertNull()` to check that we get out of the method and "nothing"  is returned.

In the 2nd commit fixup the "risky" unit tests.