### PR TITLE
Add encryption version fix command

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,6 +34,7 @@
 		<command>OCA\Encryption\Command\RecreateMasterKey</command>
 		<command>OCA\Encryption\Command\MigrateKeys</command>
 		<command>OCA\Encryption\Command\HSMDaemon</command>
+		<command>OCA\Encryption\Command\FixEncryptedVersion</command>
 	</commands>
 	<settings>
 		<admin>OCA\Encryption\Panels\Admin</admin>

--- a/lib/Command/FixEncryptedVersion.php
+++ b/lib/Command/FixEncryptedVersion.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Command;
+
+use OC\Files\Cache\Cache;
+use OC\Files\View;
+use OC\HintException;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixEncryptedVersion extends Command {
+	/** @var IRootFolder  */
+	private $rootFolder;
+
+	/** @var IUserManager  */
+	private $userManager;
+
+	/** @var View  */
+	private $view;
+
+	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->view = $view;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('encryption:fixencryptedversion')
+			->setDescription('Fix the encrypted version if the encrypted file(s) are not downloadable.')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'The user id whose files needs fix'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$user = $input->getArgument('user');
+
+		if ($user === null) {
+			$output->writeln("<error>No user provided.</error>\n");
+		}
+
+		if ($this->userManager->get($user) === null) {
+			$output->writeln("<error>User $user does not exist. Please provide a valid user id</error>");
+			return 1;
+		}
+		$this->walkUserFolder($user, $output);
+	}
+
+	/**
+	 * @param string $user
+	 * @param OutputInterface $output
+	 */
+	private function walkUserFolder($user, OutputInterface $output) {
+		$this->setupUserFs($user);
+		$directories = [];
+		$directories[] = '/' . $user . '/files';
+		while ($root = \array_pop($directories)) {
+			$directoryContent = $this->view->getDirectoryContent($root);
+			foreach ($directoryContent as $file) {
+				$path = $root . '/' . $file['name'];
+				if ($this->view->is_dir($path)) {
+					$directories[] = $path;
+				} else {
+					$output->writeln("Verifying the content of file $path");
+					$this->verifyFileContent($path, $output);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 * @param bool $ignoreCorrectEncVersionCall, setting this variable to false avoids recursion
+	 */
+	private function verifyFileContent($path, OutputInterface $output, $ignoreCorrectEncVersionCall = true) {
+		try {
+			/**
+			 * In encryption, the files are read in a block size of 8192 bytes
+			 * Read block size of 8192 and a bit more (808 bytes)
+			 * If there is any problem, the first block should throw the signature
+			 * mismatch error. Which as of now, is enough to proceed ahead to
+			 * correct the encrypted version.
+			 */
+			if ($this->view->readfilePart($path, 0, 9000) !== false) {
+				$output->writeln("<info>The file $path is: OK</info>");
+			}
+			return true;
+		} catch (HintException $e) {
+			\OC::$server->getLogger()->warning("Issue: " . $e->getMessage());
+			//If allowOnce is set to false, this becomes recursive.
+			if ($ignoreCorrectEncVersionCall === true) {
+				//Lets rectify the file by correcting encrypted version
+				$output->writeln("<info>Attempting to fix the path: $path</info>");
+				return $this->correctEncryptedVersion($path, $output);
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 */
+	private function correctEncryptedVersion($path, OutputInterface $output) {
+		$fileInfo = $this->view->getFileInfo($path);
+		$fileId = $fileInfo->getId();
+		$encryptedVersion = $fileInfo->getEncryptedVersion();
+		$wrongEncryptedVersion = $encryptedVersion;
+
+		$storage = $fileInfo->getStorage();
+
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileId);
+
+		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script under the owner of share</info>");
+			return true;
+		}
+
+		if ($encryptedVersion >= 0) {
+			//test by decrementing the value till 1 and if nothing works try incrementing
+			$encryptedVersion--;
+			while ($encryptedVersion > 0) {
+				$cacheInfo = ['encryptedVersion' => $encryptedVersion, 'encrypted' => $encryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Decrement the encrypted version to $encryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file $path with version " . $encryptedVersion . "</info>");
+					return true;
+				}
+				$encryptedVersion--;
+			}
+
+			//So decrementing did not worked. Now lets increment. Max increment is till 5
+			$increment = 1;
+			while ($increment <= 5) {
+				/**
+				 * The wrongEncryptedVersion would not be incremented so nothing to worry here.
+				 * Only the newEncryptedVersion is incremented.
+				 * For example if the wrong encrypted version is 4 then
+				 * cycle1 -> newEncryptedVersion = 5 ( 4 + 1)
+				 * cycle2 -> newEncryptedVersion = 6 ( 4 + 2)
+				 * cycle3 -> newEncryptedVersion = 7 ( 4 + 3)
+				 */
+				$newEncryptedVersion = $wrongEncryptedVersion + $increment;
+
+				$cacheInfo = ['encryptedVersion' => $newEncryptedVersion, 'encrypted' => $newEncryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Increment the encrypted version to $newEncryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file $path with version " . $newEncryptedVersion . "</info>");
+					return true;
+				}
+				$increment++;
+			}
+		}
+	}
+
+	/**
+	 * Setup user file system
+	 * @param string $uid
+	 */
+	private function setupUserFs($uid) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($uid);
+	}
+}

--- a/tests/unit/Command/FixEncryptedVersionTest.php
+++ b/tests/unit/Command/FixEncryptedVersionTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Tests\Command;
+
+use OC\Files\Cache\Cache;
+use OC\Files\View;
+use OCA\Encryption\Command\FixEncryptedVersion;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Session;
+use OCA\Encryption\Util;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use OCA\Encryption\Users\Setup;
+use Test\TestCase;
+
+/**
+ * Class FixEncryptedVersionTest
+ *
+ * @group DB
+ * @package OCA\Encryption\Tests\Command
+ */
+class FixEncryptedVersionTest extends TestCase {
+	const TEST_ENCRYPTION_VERSION_AFFECTED_USER = 'test_enc_version_affected_user1';
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var View */
+	private $view;
+
+	/** @var FixEncryptedVersion */
+	private $fixEncryptedVersion;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		//Enable encryption app
+		\OC_App::enable("encryption");
+		//Enable encryption
+		\OC::$server->getConfig()->setAppValue('core', 'encryption_enabled', 'yes');
+		//Enable Masterkey
+		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
+		$crypt = new Crypt(\OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getL10N('encryption'));
+		$encryptionSession = new Session(\OC::$server->getSession());
+		$view = new View("/");
+		$encryptionUtil = new Util($view, $crypt, \OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getUserManager());
+		$keyManager = new KeyManager(\OC::$server->getEncryptionKeyStorage(),
+			$crypt, \OC::$server->getConfig(), \OC::$server->getUserSession(),
+			$encryptionSession, \OC::$server->getLogger(), $encryptionUtil);
+		$userSetup = new Setup(\OC::$server->getLogger(), \OC::$server->getUserSession(), $crypt, $keyManager);
+		$userSetup->setupSystem();
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER);
+		if ($user !== null) {
+			$user->delete();
+		}
+		\OC_App::disable('encryption');
+		\OC::$server->getConfig()->deleteAppValue('core', 'encryption_enabled');
+		\OC::$server->getConfig()->deleteAppValue('core', 'default_encryption_module');
+		\OC::$server->getConfig()->deleteAppValues('encryption');
+	}
+
+	public function setUp() {
+		parent::setUp();
+		$this->rootFolder = \OC::$server->getRootFolder();
+		$this->userManager = \OC::$server->getUserManager();
+		$this->view = new View("/");
+		$this->fixEncryptedVersion = new FixEncryptedVersion($this->rootFolder, $this->userManager, $this->view);
+		$this->commandTester = new CommandTester($this->fixEncryptedVersion);
+	}
+
+	/**
+	 * In this test the encrypted version is set to zero whereas it should have been
+	 * set to a positive non zero number.
+	 */
+	public function testEncryptedVersionZero() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('world.txt', 'a test string for world');
+
+		$fileInfo = $view->getFileInfo('hello.txt');
+
+		$storage = $fileInfo->getStorage();
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileInfo->getId());
+
+		//Now change the encrypted version to zero
+		$cacheInfo = ['encryptedVersion' => 0, 'encrypted' => 0];
+		$cache->put($fileCache->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Increment the encrypted version to 1
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 1
+Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
+The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
+The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
+The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
+The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
+The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+
+	/**
+	 * In this test the encrypted version of the file is less than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionLessThanOriginalValue() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Yet another value');
+		$view->file_put_contents('hello.txt', 'Lets modify again1');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to two
+		$cacheInfo = ['encryptedVersion' => 2, 'encrypted' => 2];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 1, 'encrypted' => 1];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 1
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+Increment the encrypted version to 6
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 6
+Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
+The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Increment the encrypted version to 2
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/world.txt with version 5
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
+The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
+The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
+The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
+The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+
+	/**
+	 * In this test the encrypted version of the file is greater than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionGreaterThanOriginalValue() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to fifteem
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 9
+Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
+The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file /test_enc_version_affected_user1/files/world.txt with version 9
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
+The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
+The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
+The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
+Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
+The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
+", $output);
+		/**
+		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * where as the ob_get_level is found to be zero.
+		 */
+		\ob_start();
+	}
+}

--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -458,5 +458,11 @@ class UserHooksTest extends TestCase {
 					$this->config
 				]
 			)->setMethods(['setupFS'])->getMock();
+		\OC_App::enable('encryption');
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		\OC_App::disable('encryption');
 	}
 }


### PR DESCRIPTION
Add a new command to fix the encryption
version. This would help the admin to
fix the issues related to encryption version
mismatch for the files.

Signed-off-by: Sujith H <sharidasan@owncloud.com>