### PR TITLE
Fix minor typo in FixEncryptedVersionTest

### DIFF
--- a/tests/unit/Command/FixEncryptedVersionTest.php
+++ b/tests/unit/Command/FixEncryptedVersionTest.php
@@ -147,7 +147,7 @@ The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();
@@ -231,7 +231,7 @@ The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();
@@ -316,7 +316,7 @@ The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
 ", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestcCase.php is found to be 1
+		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
 		 * where as the ob_get_level is found to be zero.
 		 */
 		\ob_start();


### PR DESCRIPTION
I really did this to demonstrate the other CI issues we had yesterday. Now the QA tarball problems are corrected and CI passes. We may as well fix this typo.

Backport to core `stable10` is in https://github.com/owncloud/core/pull/35000