### PR TITLE
Fix minor wording corrections in command

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -2,7 +2,7 @@
 /**
  * @author Patrick Jahns <github@patrickjahns.de>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license GPL-2.0
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/appinfo/Migrations/Version20170913113840.php
+++ b/appinfo/Migrations/Version20170913113840.php
@@ -2,7 +2,7 @@
 /**
  * @author Sujith Haridasan <sharidasan@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/css/settings-admin.css
+++ b/css/settings-admin.css
@@ -1,7 +1,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  *
- * @copyright Copyright (c) 2019, ownCloud, GbmH.
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/css/settings-admin.css
+++ b/css/settings-admin.css
@@ -1,7 +1,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  *
- * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Copyright (c) 2019, ownCloud, GbmH.
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Command/FixEncryptedVersion.php
+++ b/lib/Command/FixEncryptedVersion.php
@@ -51,12 +51,12 @@ class FixEncryptedVersion extends Command {
 		parent::configure();
 
 		$this
-			->setName('encryption:fixencryptedversion')
+			->setName('encryption:fix-encrypted-version')
 			->setDescription('Fix the encrypted version if the encrypted file(s) are not downloadable.')
 			->addArgument(
 				'user',
 				InputArgument::REQUIRED,
-				'The user id whose files needs fix'
+				'The id of the user whose files need fixing'
 			);
 	}
 
@@ -64,11 +64,11 @@ class FixEncryptedVersion extends Command {
 		$user = $input->getArgument('user');
 
 		if ($user === null) {
-			$output->writeln("<error>No user provided.</error>\n");
+			$output->writeln("<error>No user id provided.</error>\n");
 		}
 
 		if ($this->userManager->get($user) === null) {
-			$output->writeln("<error>User $user does not exist. Please provide a valid user id</error>");
+			$output->writeln("<error>User id $user does not exist. Please provide a valid user id</error>");
 			return 1;
 		}
 		$this->walkUserFolder($user, $output);
@@ -142,7 +142,7 @@ class FixEncryptedVersion extends Command {
 		$fileCache = $cache->get($fileId);
 
 		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
-			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script under the owner of share</info>");
+			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script for the owner of share</info>");
 			return true;
 		}
 
@@ -154,17 +154,17 @@ class FixEncryptedVersion extends Command {
 				$cache->put($fileCache->getPath(), $cacheInfo);
 				$output->writeln("<info>Decrement the encrypted version to $encryptedVersion</info>");
 				if ($this->verifyFileContent($path, $output, false) === true) {
-					$output->writeln("<info>Fixed the file $path with version " . $encryptedVersion . "</info>");
+					$output->writeln("<info>Fixed the file: $path with version " . $encryptedVersion . "</info>");
 					return true;
 				}
 				$encryptedVersion--;
 			}
 
-			//So decrementing did not worked. Now lets increment. Max increment is till 5
+			//So decrementing did not work. Now lets increment. Max increment is till 5
 			$increment = 1;
 			while ($increment <= 5) {
 				/**
-				 * The wrongEncryptedVersion would not be incremented so nothing to worry here.
+				 * The wrongEncryptedVersion would not be incremented so nothing to worry about here.
 				 * Only the newEncryptedVersion is incremented.
 				 * For example if the wrong encrypted version is 4 then
 				 * cycle1 -> newEncryptedVersion = 5 ( 4 + 1)
@@ -177,7 +177,7 @@ class FixEncryptedVersion extends Command {
 				$cache->put($fileCache->getPath(), $cacheInfo);
 				$output->writeln("<info>Increment the encrypted version to $newEncryptedVersion</info>");
 				if ($this->verifyFileContent($path, $output, false) === true) {
-					$output->writeln("<info>Fixed the file $path with version " . $newEncryptedVersion . "</info>");
+					$output->writeln("<info>Fixed the file: $path with version " . $newEncryptedVersion . "</info>");
 					return true;
 				}
 				$increment++;

--- a/lib/Command/HSMDaemon.php
+++ b/lib/Command/HSMDaemon.php
@@ -2,7 +2,7 @@
 /**
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Command/MigrateKeys.php
+++ b/lib/Command/MigrateKeys.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Command/RecreateMasterKey.php
+++ b/lib/Command/RecreateMasterKey.php
@@ -2,7 +2,7 @@
 /**
 * @author Sujith Haridasan <sharidasan@owncloud.com>
 *
-* @copyright Copyright (c) 2017, ownCloud GmbH
+* @copyright Copyright (c) 2019, ownCloud GmbH
 * @license AGPL-3.0
 *
 * This code is free software: you can redistribute it and/or modify

--- a/lib/Command/SelectEncryptionType.php
+++ b/lib/Command/SelectEncryptionType.php
@@ -2,7 +2,7 @@
 /**
 * @author Björn Schießle <bjoern@schiessle.org>
 *
-* @copyright Copyright (c) 2017, ownCloud GmbH
+* @copyright Copyright (c) 2019, ownCloud GmbH
 * @license AGPL-3.0
 *
 * This code is free software: you can redistribute it and/or modify

--- a/lib/Controller/RecoveryController.php
+++ b/lib/Controller/RecoveryController.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Joas Schilling <coding@schilljs.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -140,11 +140,11 @@ class SettingsController extends Controller {
 		if ($result === true) {
 			$this->session->setStatus(Session::INIT_SUCCESSFUL);
 			return new DataResponse(
-				['message' => (string)$this->l->t('Private key password successfully updated.')]
+				['message' => (string) $this->l->t('Private key password successfully updated.')]
 			);
 		} else {
 			return new DataResponse(
-				['message' => (string)$errorMessage],
+				['message' => (string) $errorMessage],
 				Http::STATUS_BAD_REQUEST
 			);
 		}

--- a/lib/Controller/StatusController.php
+++ b/lib/Controller/StatusController.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -6,7 +6,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Crypto/CryptHSM.php
+++ b/lib/Crypto/CryptHSM.php
@@ -6,7 +6,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Crypto/DecryptAll.php
+++ b/lib/Crypto/DecryptAll.php
@@ -2,7 +2,7 @@
 /**
  * @author Björn Schießle <bjoern@schiessle.org>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Crypto/EncryptAll.php
+++ b/lib/Crypto/EncryptAll.php
@@ -289,7 +289,7 @@ class EncryptAll {
 	 */
 	protected function encryptFile($path) {
 		$source = $path;
-		$target = $path . '.encrypted.' . \time() . '.part';
+		$target = $path . '.encrypted.' . $this->getTimeStamp() . '.part';
 
 		try {
 			$version = $this->keyManager->getVersion($source, $this->rootView);
@@ -379,6 +379,15 @@ class EncryptAll {
 	protected function setupUserFS($uid) {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($uid);
+	}
+
+	/**
+	 * get current timestamp
+	 *
+	 * @return int
+	 */
+	protected function getTimeStamp() {
+		return \time();
 	}
 
 	/**

--- a/lib/Crypto/EncryptAll.php
+++ b/lib/Crypto/EncryptAll.php
@@ -4,7 +4,7 @@
  * @author Roeland Jago Douma <rullzer@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Crypto/Encryption.php
+++ b/lib/Crypto/Encryption.php
@@ -162,7 +162,7 @@ class Encryption implements IEncryptionModule {
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 * @param string|null $sourceFileOfRename Either false or the name of source file to be renamed.
-	 * 						This is helpful for revision increment during move operation between storage.
+	 * 										  This is helpful for revision increment during move operation between storage.
 	 *
 	 * @return array $header contain data as key-value pairs which should be
 	 *                       written to the header, in case of a write operation

--- a/lib/Crypto/Encryption.php
+++ b/lib/Crypto/Encryption.php
@@ -7,7 +7,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Exceptions/MultiKeyDecryptException.php
+++ b/lib/Exceptions/MultiKeyDecryptException.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Exceptions/MultiKeyEncryptException.php
+++ b/lib/Exceptions/MultiKeyEncryptException.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Exceptions/PrivateKeyMissingException.php
+++ b/lib/Exceptions/PrivateKeyMissingException.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Exceptions/PublicKeyMissingException.php
+++ b/lib/Exceptions/PublicKeyMissingException.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/HookManager.php
+++ b/lib/HookManager.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Clark Tomlinson <fallen013@gmail.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Hooks/Contracts/IHook.php
+++ b/lib/Hooks/Contracts/IHook.php
@@ -2,7 +2,7 @@
 /**
  * @author Clark Tomlinson <fallen013@gmail.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -5,7 +5,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -240,7 +240,7 @@ class UserHooks implements IHook {
 	public function setPassphrase($params) {
 		$privateKey = null;
 		$user = null;
-		//Check if a session is there or not
+		//Check if the session is there or not
 		if ($this->user->getUser() !== null) {
 			// Get existing decrypted private key
 			$privateKey = $this->session->getPrivateKey();

--- a/lib/JWT.php
+++ b/lib/JWT.php
@@ -2,7 +2,7 @@
 /**
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/KeyManager.php
+++ b/lib/KeyManager.php
@@ -6,7 +6,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Migration.php
+++ b/lib/Migration.php
@@ -5,7 +5,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Panels/Admin.php
+++ b/lib/Panels/Admin.php
@@ -2,7 +2,7 @@
 /**
  * @author Tom Needham <tom@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Panels/Personal.php
+++ b/lib/Panels/Personal.php
@@ -2,7 +2,7 @@
 /**
  * @author Tom Needham <tom@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Recovery.php
+++ b/lib/Recovery.php
@@ -5,7 +5,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Session.php
+++ b/lib/Session.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Users/Setup.php
+++ b/lib/Users/Setup.php
@@ -5,7 +5,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -4,7 +4,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Phil Davis <phil.davis@inf.org>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Command/FixEncryptedVersionTest.php
+++ b/tests/unit/Command/FixEncryptedVersionTest.php
@@ -102,7 +102,7 @@ class FixEncryptedVersionTest extends TestCase {
 	 * In this test the encrypted version is set to zero whereas it should have been
 	 * set to a positive non zero number.
 	 */
-	public function testEncryptedVersionZero() {
+	public function testEncryptedVersionIsNotZero() {
 		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
 		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
 
@@ -130,7 +130,7 @@ class FixEncryptedVersionTest extends TestCase {
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Increment the encrypted version to 1
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 1
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1
 Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
 The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
@@ -208,7 +208,7 @@ Increment the encrypted version to 4
 Increment the encrypted version to 5
 Increment the encrypted version to 6
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 6
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6
 Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
 The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
@@ -218,7 +218,7 @@ Increment the encrypted version to 3
 Increment the encrypted version to 4
 Increment the encrypted version to 5
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/world.txt with version 5
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5
 Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
 The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
 Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
@@ -291,7 +291,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/hello.txt with version 9
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9
 Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
 The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
 Verifying the content of file /test_enc_version_affected_user1/files/world.txt
@@ -303,7 +303,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file /test_enc_version_affected_user1/files/world.txt with version 9
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9
 Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
 The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
 Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg

--- a/tests/unit/Command/RecreateMasterKeyTest.php
+++ b/tests/unit/Command/RecreateMasterKeyTest.php
@@ -2,7 +2,7 @@
 /**
  * @author Sujith Haridasan <sharidasan@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Command/TestEnableMasterKey.php
+++ b/tests/unit/Command/TestEnableMasterKey.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Joas Schilling <coding@schilljs.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Command/TestEnableUserKey.php
+++ b/tests/unit/Command/TestEnableUserKey.php
@@ -2,7 +2,7 @@
 /**
  * @author Sujith H <sharidasan@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Controller/RecoveryControllerTest.php
+++ b/tests/unit/Controller/RecoveryControllerTest.php
@@ -3,7 +3,7 @@
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Joas Schilling <coding@schilljs.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -4,7 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Controller/StatusControllerTest.php
+++ b/tests/unit/Controller/StatusControllerTest.php
@@ -4,7 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Crypto/CryptTest.php
+++ b/tests/unit/Crypto/CryptTest.php
@@ -5,7 +5,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Crypto/DecryptAllTest.php
+++ b/tests/unit/Crypto/DecryptAllTest.php
@@ -3,7 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Joas Schilling <coding@schilljs.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Crypto/EncryptAllTest.php
+++ b/tests/unit/Crypto/EncryptAllTest.php
@@ -4,7 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Crypto/EncryptionTest.php
+++ b/tests/unit/Crypto/EncryptionTest.php
@@ -4,7 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/HookManagerTest.php
+++ b/tests/unit/HookManagerTest.php
@@ -4,7 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -6,7 +6,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/KeyManagerTest.php
+++ b/tests/unit/KeyManagerTest.php
@@ -6,7 +6,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/MigrationTest.php
+++ b/tests/unit/MigrationTest.php
@@ -6,7 +6,7 @@
  * @author Roeland Jago Douma <rullzer@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Panels/AdminTest.php
+++ b/tests/unit/Panels/AdminTest.php
@@ -2,7 +2,7 @@
 /**
  * @author Tom Needham <tom@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Panels/PersonalTest.php
+++ b/tests/unit/Panels/PersonalTest.php
@@ -2,7 +2,7 @@
 /**
  * @author Tom Needham <tom@owncloud.com>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/RecoveryTest.php
+++ b/tests/unit/RecoveryTest.php
@@ -6,7 +6,7 @@
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/SessionTest.php
+++ b/tests/unit/SessionTest.php
@@ -5,7 +5,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/Users/SetupTest.php
+++ b/tests/unit/Users/SetupTest.php
@@ -5,7 +5,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -5,7 +5,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @copyright Copyright (c) 2019, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Fix minor wording corrections in the command.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

Also added here to help with #118 code alignment: (by phil-davis)
- Bump all ownCloud copyright consistently to 2019
- Fix GmbH typo in copyright
- Adjust encryption code format to match what is in core stable10

That gets the code here closer to core stable10. See core `stable10` PR https://github.com/owncloud/core/pull/35015 for changes in the opposite direction, that get core `stable10` closer to the `encryption` app repo.