### PR TITLE
Fixing encrypted version test

### DIFF
--- a/tests/unit/Command/FixEncryptedVersionTest.php
+++ b/tests/unit/Command/FixEncryptedVersionTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Encryption\Tests\Command;
 
+use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Encryption\Command\FixEncryptedVersion;
 use OCA\Encryption\Crypto\Crypt;
@@ -87,6 +88,7 @@ class FixEncryptedVersionTest extends TestCase {
 		\OC::$server->getConfig()->deleteAppValue('core', 'encryption_enabled');
 		\OC::$server->getConfig()->deleteAppValue('core', 'default_encryption_module');
 		\OC::$server->getConfig()->deleteAppValues('encryption');
+		Filesystem::getLoader()->removeStorageWrapper("oc_encryption");
 	}
 
 	public function setUp() {
@@ -126,24 +128,14 @@ class FixEncryptedVersionTest extends TestCase {
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Increment the encrypted version to 1
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1
-Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
-The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
-The file /test_enc_version_affected_user1/files/world.txt is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
-The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
-The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
-The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
-The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
-", $output);
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
@@ -198,9 +190,10 @@ The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
-The file /test_enc_version_affected_user1/files/foo.txt is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Decrement the encrypted version to 1
 Increment the encrypted version to 3
@@ -208,26 +201,15 @@ Increment the encrypted version to 4
 Increment the encrypted version to 5
 Increment the encrypted version to 6
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6
-Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
-The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Increment the encrypted version to 2
 Increment the encrypted version to 3
 Increment the encrypted version to 4
 Increment the encrypted version to 5
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
-The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
-The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
-The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
-The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
-", $output);
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
@@ -280,9 +262,10 @@ The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
 		]);
 
 		$output = $this->commandTester->getDisplay();
-		$this->assertEquals("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
-The file /test_enc_version_affected_user1/files/foo.txt is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
 Decrement the encrypted version to 14
 Decrement the encrypted version to 13
@@ -291,10 +274,8 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/hello.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9
-Verifying the content of file /test_enc_version_affected_user1/files/ownCloud Manual.pdf
-The file /test_enc_version_affected_user1/files/ownCloud Manual.pdf is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9", $output);
+		$this->assertContains("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
 Decrement the encrypted version to 14
 Decrement the encrypted version to 13
@@ -303,16 +284,7 @@ Decrement the encrypted version to 11
 Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/world.txt is: OK
-Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Paris.jpg
-The file /test_enc_version_affected_user1/files/Photos/Paris.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg
-The file /test_enc_version_affected_user1/files/Photos/San Francisco.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg
-The file /test_enc_version_affected_user1/files/Photos/Squirrel.jpg is: OK
-Verifying the content of file /test_enc_version_affected_user1/files/Documents/Example.odt
-The file /test_enc_version_affected_user1/files/Documents/Example.odt is: OK
-", $output);
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9", $output);
 		/**
 		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
 		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1


### PR DESCRIPTION
Its better to verify if the command output contains specific
strings, instead of grabbing the whole command output and
comparing with string equal.

Signed-off-by: Sujith H <sharidasan@owncloud.com>