### PR TITLE
Add acceptance test for checking file access after recreating master key in encryption

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2729,3 +2729,17 @@ matrix:
       ENCRYPTION_TYPE: user-keys
       DB_TYPE: mysql
       DB_HOST: mysql
+
+    ## encryption WebUI acceptance tests master-keys encryption
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SERVER: true
+      NEED_SELENIUM: true
+      NEED_EMAIL: true
+      BEHAT_SUITE: webUIMasterKeyType
+      TEST_SUITE: web-acceptance
+      ENCRYPTION_TYPE: masterkey
+      DB_TYPE: mysql
+      DB_HOST: mysql

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -28,6 +28,19 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
 
+    webUIMasterKeyType:
+      paths:
+        - '%paths.base%/../features/webUIMasterKeyType'
+      contexts:
+        - EncryptionContext:
+        - WebUIAdminEncryptionSettingsContext:
+        - WebUIPersonalEncryptionSettingsContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIFilesContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:
           filename: report.xml

--- a/tests/acceptance/features/webUIMasterKeyType/webUIMasterKeys.feature
+++ b/tests/acceptance/features/webUIMasterKeyType/webUIMasterKeys.feature
@@ -1,0 +1,28 @@
+@webUI @skipOnEncryptionType:user-keys @skipOnStorage:ceph
+Feature: encrypt files using master keys
+  As an admin
+  I want to be able to encrypt user files using master keys
+  So that I can use a common key to encrypt files of all user
+
+  Scenario: user cannot access their file after recreating master key with re-login
+    Given user "user0" has been created with default attributes
+    And the administrator has set the encryption type to "masterkey"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
+    And user "user0" has logged in using the webUI
+    When the administrator successfully recreates the encryption masterkey using the occ command
+    Then the command output should contain the text 'Note: All users are required to relogin.'
+    When the user opens file "lorem.txt" expecting to fail using the webUI
+    Then the user should be redirected to the general exception webUI page with the title "%productname%"
+    And the title of the exception on general exception webUI page should be "Forbidden"
+    And a message should be displayed on the general exception webUI page containing "Encryption not ready"
+
+  Scenario: user can access their file after recreating master key with re-login
+    Given user "user0" has been created with default attributes
+    And the administrator has set the encryption type to "masterkey"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
+    And user "user0" has logged in using the webUI
+    When the administrator successfully recreates the encryption masterkey using the occ command
+    And the user re-logs in as "user0" using the webUI
+    And the user opens file "lorem.txt" using the webUI
+    Then no dialog should be displayed on the webUI
+    And the user should be redirected to a webUI page with the title "Files - %productname%"


### PR DESCRIPTION
Add acceptence test to check that user have to relog in in order to access their files after the administrator has recreated the master key in encryption.

Fixes #123 

~~Note: This requires https://github.com/owncloud/core/pull/35246 to be merged first~~