### PR TITLE
Add changelog for 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## 1.4.0
+
+### Added
+
+- `encryption:fixencryptedversion` command to address issues related to encrypted versions  [#115](https://github.com/owncloud/encryption/pull/115)
+
+### Changed
+
+- Improved wording for several user/administrator interactions [#21](https://github.com/owncloud/encryption/pull/21) [#117](https://github.com/owncloud/encryption/pull/117)
+
+### Fixed
+
+- Issues with recreating masterkeys when HSM is used [#128](https://github.com/owncloud/encryption/pull/128)
+
+
+[Unreleased]: https://github.com/owncloud/encryption/compare/v1.4.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 app_name=$(notdir $(CURDIR))
 build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist
-doc_files=README.md LICENSE
+doc_files=README.md CHANGELOG.md LICENSE
 src_dirs=appinfo css img js l10n lib templates
 all_src=$(src_dirs) $(doc_files)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 		<admin>admin-encryption</admin>
 	</documentation>
 	<rememberlogin>false</rememberlogin>
-	<version>1.3.1</version>
+	<version>1.4.0</version>
 	<category>security</category>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
Update changelog to reflect changes in 1.4.0 ( these are the changes from owncloud [10.2.1](https://github.com/owncloud/core/commits/v10.2.1/apps/encryption) to [10.3](https://github.com/owncloud/core/commits/45a5d8faa20eda4ae4c09e44e477001787dcfe19/apps/encryption) )

