### PR TITLE
Specify ENCRYPTION_TYPE var when running core tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -236,6 +236,7 @@ pipeline:
       - SELENIUM_PORT=4444
       - PLATFORM=Linux
       - MAILHOG_HOST=email
+      - ENCRYPTION_TYPE=${ENCRYPTION_TYPE}
       - DIVIDE_INTO_NUM_PARTS=20
       - RUN_PART=${PART}
     commands:
@@ -252,6 +253,7 @@ pipeline:
     environment:
       - TEST_SERVER_URL=http://owncloud
       - MAILHOG_HOST=email
+      - ENCRYPTION_TYPE=${ENCRYPTION_TYPE}
       - DIVIDE_INTO_NUM_PARTS=20
       - RUN_PART=${PART}
     commands:


### PR DESCRIPTION
The acceptance test `run.sh` output was saying stuff like:
```
Running webUIUserKeysType tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnOcV10&&~@skipOnOcV10.3&&~@skipOnOcV10.3.0&&~@skipOnEncryption&&~@skipOnEncryptionType:&&~@skip&&@webUI on browser 'chrome' on platform 'Linux'
```
The actual encryption type was missing from `~@skipOnEncryptionType:` - it should say `~@skipOnEncryptionType:user-keys` or `~@skipOnEncryptionType:masterkey`