### PR TITLE
Drop PHP 7.0 from drone CI

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -12,7 +12,6 @@ config = {
 	'codestyle': {
 		'ordinary' : {
 			'phpVersions': [
-				'7.0',
 				'7.1',
 				'7.2',
 				'7.3',
@@ -35,7 +34,6 @@ config = {
 		},
 		'withoutCoverage' : {
 			'phpVersions': [
-				'7.0',
 				'7.2',
 				'7.3',
 			],
@@ -64,7 +62,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -90,7 +88,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -116,7 +114,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -147,7 +145,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -179,7 +177,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -210,7 +208,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -242,7 +240,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -274,7 +272,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -307,7 +305,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -339,7 +337,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -372,7 +370,7 @@ config = {
 			'extraSetup': [
 				{
 					'name': 'configure-app',
-					'image': 'owncloudci/php:7.0',
+					'image': 'owncloudci/php:7.1',
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
@@ -427,7 +425,7 @@ def codestyle():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 	}
 
 	if 'defaults' in config:
@@ -616,7 +614,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 	}
 
 	if 'defaults' in config:
@@ -688,7 +686,7 @@ def build():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'commands': [
 			'make dist'
 		],
@@ -813,13 +811,13 @@ def javascript():
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.0') +
-			setupServerAndApp('7.0', params['logLevel']) +
+			installApp('7.1') +
+			setupServerAndApp('7.1', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.0',
+				'image': 'owncloudci/php:7.1',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [
@@ -866,7 +864,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
@@ -1033,7 +1031,7 @@ def acceptance():
 	default = {
 		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
@@ -1610,7 +1608,7 @@ def setupCeph(serviceParams):
 
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 ceph:80',
+		'wait-for-it -t 120 ceph:80',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 		'cd /var/www/owncloud/server',
@@ -1618,7 +1616,7 @@ def setupCeph(serviceParams):
 
 	return [{
 		'name': 'setup-ceph',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
@@ -1638,7 +1636,7 @@ def setupScality(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 scality:8000',
+		'wait-for-it -t 120 scality:8000',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
 		'cd /var/www/owncloud/server'
@@ -1646,7 +1644,7 @@ def setupScality(serviceParams):
 
 	return [{
 		'name': 'setup-scality',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'php occ s3:create-bucket owncloud --accept-warning'

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,32 +1,6 @@
 ---
 kind: pipeline
 type: docker
-name: coding-standard-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/encryption
-
-steps:
-- name: coding-standard
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-style
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
 name: coding-standard-php7.1
 
 platform:
@@ -163,7 +137,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -239,7 +212,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -314,197 +286,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-sqlite
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-mysql5.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.5
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: phpunit-php7.0-postgres9.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: postgres
-    db_name: owncloud
-    db_password: owncloud
-    db_type: pgsql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: phpunit-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-unit
-
-services:
-- name: postgres
-  pull: always
-  image: postgres:9.4
-  environment:
-    POSTGRES_DB: owncloud
-    POSTGRES_PASSWORD: owncloud
-    POSTGRES_USER: owncloud
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -561,7 +342,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -628,7 +408,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -694,7 +473,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -751,7 +529,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -818,7 +595,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -884,7 +660,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -892,7 +667,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliEncryption-master-mysql5.5-php7.0
+name: cliEncryption-master-mysql5.5-php7.1
 
 platform:
   os: linux
@@ -918,7 +693,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -929,7 +704,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -948,7 +723,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -957,13 +732,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -984,7 +759,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1001,7 +776,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1009,7 +783,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliEncryption-master-postgres9.4-php7.0
+name: cliEncryption-master-postgres9.4-php7.1
 
 platform:
   os: linux
@@ -1035,7 +809,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1046,7 +820,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1065,7 +839,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1074,13 +848,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1100,7 +874,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1117,7 +891,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1125,7 +898,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliEncryption-latest-mysql5.5-php7.0
+name: cliEncryption-latest-mysql5.5-php7.1
 
 platform:
   os: linux
@@ -1151,7 +924,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1162,7 +935,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1181,7 +954,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1190,13 +963,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1217,7 +990,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1234,7 +1007,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1242,7 +1014,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: cliEncryption-latest-postgres9.4-php7.0
+name: cliEncryption-latest-postgres9.4-php7.1
 
 platform:
   os: linux
@@ -1268,7 +1040,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1279,7 +1051,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1298,7 +1070,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1307,13 +1079,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1333,7 +1105,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1350,7 +1122,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1358,7 +1129,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIMasterKey-master-chrome-mysql5.5-php7.0
+name: webUIMasterKey-master-chrome-mysql5.5-php7.1
 
 platform:
   os: linux
@@ -1384,7 +1155,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1395,7 +1166,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1414,7 +1185,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1423,13 +1194,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1465,7 +1236,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1482,7 +1253,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1490,7 +1260,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIMasterKey-latest-chrome-mysql5.5-php7.0
+name: webUIMasterKey-latest-chrome-mysql5.5-php7.1
 
 platform:
   os: linux
@@ -1516,7 +1286,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1527,7 +1297,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1546,7 +1316,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1555,13 +1325,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1597,7 +1367,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1614,7 +1384,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1622,7 +1391,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIUserKeys-master-chrome-mysql5.5-php7.0
+name: webUIUserKeys-master-chrome-mysql5.5-php7.1
 
 platform:
   os: linux
@@ -1648,7 +1417,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1659,7 +1428,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1678,7 +1447,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1687,145 +1456,13 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-webui
-  environment:
-    BEHAT_SUITE: webUIUserKeysType
-    BROWSER: chrome
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.5
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIUserKeys-latest-chrome-mysql5.5-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: latest
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type user-keys --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -1861,7 +1498,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -1878,7 +1515,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -1886,7 +1522,138 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-1-master-mysql5.7-php7.0
+name: webUIUserKeys-latest-chrome-mysql5.5-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type user-keys --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserKeysType
+    BROWSER: chrome
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiCoreMKey-25-1-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -1912,7 +1679,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -1930,7 +1697,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -1950,7 +1717,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -1969,7 +1736,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -1978,14 +1745,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2008,7 +1775,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2020,7 +1787,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2037,7 +1804,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2045,7 +1811,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-2-master-mysql5.7-php7.0
+name: apiCoreMKey-25-2-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2071,7 +1837,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2089,7 +1855,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2109,7 +1875,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2128,7 +1894,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2137,14 +1903,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2167,7 +1933,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2179,7 +1945,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2196,7 +1962,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2204,7 +1969,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-3-master-mysql5.7-php7.0
+name: apiCoreMKey-25-3-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2230,7 +1995,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2248,7 +2013,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2268,7 +2033,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2287,7 +2052,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2296,14 +2061,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2326,7 +2091,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2338,7 +2103,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2355,7 +2120,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2363,7 +2127,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-4-master-mysql5.7-php7.0
+name: apiCoreMKey-25-4-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2389,7 +2153,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2407,7 +2171,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2427,7 +2191,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2446,7 +2210,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2455,14 +2219,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2485,7 +2249,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2497,7 +2261,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2514,7 +2278,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2522,7 +2285,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-5-master-mysql5.7-php7.0
+name: apiCoreMKey-25-5-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2548,7 +2311,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2566,7 +2329,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2586,7 +2349,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2605,7 +2368,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2614,14 +2377,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2644,7 +2407,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2656,7 +2419,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2673,7 +2436,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2681,7 +2443,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-6-master-mysql5.7-php7.0
+name: apiCoreMKey-25-6-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2707,7 +2469,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2725,7 +2487,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2745,7 +2507,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2764,7 +2526,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2773,14 +2535,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2803,7 +2565,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2815,7 +2577,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2832,7 +2594,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2840,7 +2601,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-7-master-mysql5.7-php7.0
+name: apiCoreMKey-25-7-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -2866,7 +2627,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -2884,7 +2645,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -2904,7 +2665,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -2923,7 +2684,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -2932,14 +2693,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -2962,7 +2723,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2974,7 +2735,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -2991,7 +2752,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -2999,7 +2759,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-8-master-mysql5.7-php7.0
+name: apiCoreMKey-25-8-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3025,7 +2785,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3043,7 +2803,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3063,7 +2823,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3082,7 +2842,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3091,14 +2851,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3121,7 +2881,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3133,7 +2893,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3150,7 +2910,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3158,7 +2917,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-9-master-mysql5.7-php7.0
+name: apiCoreMKey-25-9-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3184,7 +2943,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3202,7 +2961,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3222,7 +2981,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3241,7 +3000,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3250,14 +3009,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3280,7 +3039,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3292,7 +3051,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3309,7 +3068,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3317,7 +3075,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-10-master-mysql5.7-php7.0
+name: apiCoreMKey-25-10-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3343,7 +3101,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3361,7 +3119,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3381,7 +3139,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3400,7 +3158,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3409,14 +3167,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3439,7 +3197,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3451,7 +3209,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3468,7 +3226,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3476,7 +3233,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-11-master-mysql5.7-php7.0
+name: apiCoreMKey-25-11-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3502,7 +3259,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3520,7 +3277,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3540,7 +3297,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3559,7 +3316,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3568,14 +3325,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3598,7 +3355,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3610,7 +3367,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3627,7 +3384,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3635,7 +3391,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-12-master-mysql5.7-php7.0
+name: apiCoreMKey-25-12-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3661,7 +3417,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3679,7 +3435,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3699,7 +3455,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3718,7 +3474,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3727,14 +3483,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3757,7 +3513,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3769,7 +3525,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3786,7 +3542,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3794,7 +3549,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-13-master-mysql5.7-php7.0
+name: apiCoreMKey-25-13-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3820,7 +3575,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3838,7 +3593,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -3858,7 +3613,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -3877,7 +3632,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -3886,14 +3641,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -3916,7 +3671,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3928,7 +3683,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -3945,7 +3700,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -3953,7 +3707,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-14-master-mysql5.7-php7.0
+name: apiCoreMKey-25-14-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -3979,7 +3733,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -3997,7 +3751,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4017,7 +3771,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4036,7 +3790,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4045,14 +3799,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4075,7 +3829,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4087,7 +3841,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4104,7 +3858,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4112,7 +3865,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-15-master-mysql5.7-php7.0
+name: apiCoreMKey-25-15-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4138,7 +3891,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4156,7 +3909,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4176,7 +3929,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4195,7 +3948,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4204,14 +3957,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4234,7 +3987,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4246,7 +3999,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4263,7 +4016,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4271,7 +4023,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-16-master-mysql5.7-php7.0
+name: apiCoreMKey-25-16-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4297,7 +4049,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4315,7 +4067,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4335,7 +4087,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4354,7 +4106,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4363,14 +4115,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4393,7 +4145,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4405,7 +4157,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4422,7 +4174,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4430,7 +4181,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-17-master-mysql5.7-php7.0
+name: apiCoreMKey-25-17-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4456,7 +4207,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4474,7 +4225,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4494,7 +4245,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4513,7 +4264,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4522,14 +4273,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4552,7 +4303,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4564,7 +4315,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4581,7 +4332,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4589,7 +4339,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-18-master-mysql5.7-php7.0
+name: apiCoreMKey-25-18-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4615,7 +4365,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4633,7 +4383,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4653,7 +4403,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4672,7 +4422,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4681,14 +4431,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4711,7 +4461,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4723,7 +4473,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4740,7 +4490,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4748,7 +4497,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-19-master-mysql5.7-php7.0
+name: apiCoreMKey-25-19-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4774,7 +4523,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4792,7 +4541,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4812,7 +4561,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4831,7 +4580,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4840,14 +4589,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -4870,7 +4619,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4882,7 +4631,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -4899,7 +4648,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -4907,7 +4655,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-20-master-mysql5.7-php7.0
+name: apiCoreMKey-25-20-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -4933,7 +4681,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -4951,7 +4699,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -4971,7 +4719,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -4990,7 +4738,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -4999,14 +4747,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5029,7 +4777,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5041,7 +4789,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5058,7 +4806,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5066,7 +4813,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-21-master-mysql5.7-php7.0
+name: apiCoreMKey-25-21-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5092,7 +4839,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5110,7 +4857,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5130,7 +4877,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5149,7 +4896,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5158,14 +4905,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5188,7 +4935,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5200,7 +4947,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5217,7 +4964,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5225,7 +4971,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-22-master-mysql5.7-php7.0
+name: apiCoreMKey-25-22-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5251,7 +4997,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5269,7 +5015,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5289,7 +5035,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5308,7 +5054,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5317,14 +5063,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5347,7 +5093,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5359,7 +5105,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5376,7 +5122,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5384,7 +5129,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-23-master-mysql5.7-php7.0
+name: apiCoreMKey-25-23-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5410,7 +5155,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5428,7 +5173,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5448,7 +5193,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5467,7 +5212,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5476,14 +5221,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5506,7 +5251,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5518,7 +5263,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5535,7 +5280,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5543,7 +5287,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-24-master-mysql5.7-php7.0
+name: apiCoreMKey-25-24-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5569,7 +5313,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5587,7 +5331,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5607,7 +5351,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5626,7 +5370,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5635,14 +5379,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5665,7 +5409,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5677,7 +5421,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5694,7 +5438,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5702,7 +5445,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-25-master-mysql5.7-php7.0
+name: apiCoreMKey-25-25-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5728,7 +5471,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5746,7 +5489,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5766,7 +5509,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5785,7 +5528,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5794,14 +5537,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5824,7 +5567,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5836,7 +5579,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5853,7 +5596,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -5861,7 +5603,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-1-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-1-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -5887,7 +5629,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -5905,7 +5647,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -5925,7 +5667,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -5944,7 +5686,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -5953,14 +5695,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -5983,7 +5725,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -5995,7 +5737,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6010,7 +5752,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6018,7 +5759,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-2-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-2-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6044,7 +5785,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6062,7 +5803,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6082,7 +5823,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6101,7 +5842,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6110,14 +5851,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6140,7 +5881,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6152,7 +5893,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6167,7 +5908,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6175,7 +5915,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-3-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-3-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6201,7 +5941,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6219,7 +5959,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6239,7 +5979,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6258,7 +5998,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6267,14 +6007,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6297,7 +6037,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6309,7 +6049,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6324,7 +6064,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6332,7 +6071,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-4-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-4-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6358,7 +6097,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6376,7 +6115,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6396,7 +6135,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6415,7 +6154,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6424,14 +6163,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6454,7 +6193,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6466,7 +6205,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6481,7 +6220,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6489,7 +6227,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-5-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-5-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6515,7 +6253,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6533,7 +6271,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6553,7 +6291,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6572,7 +6310,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6581,14 +6319,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6611,7 +6349,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6623,7 +6361,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6638,7 +6376,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6646,7 +6383,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-6-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-6-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6672,7 +6409,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6690,7 +6427,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6710,7 +6447,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6729,7 +6466,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6738,14 +6475,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6768,7 +6505,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6780,7 +6517,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6795,7 +6532,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6803,7 +6539,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-7-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-7-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6829,7 +6565,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -6847,7 +6583,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -6867,7 +6603,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -6886,7 +6622,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -6895,14 +6631,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -6925,7 +6661,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6937,7 +6673,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -6952,7 +6688,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -6960,7 +6695,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-8-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-8-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -6986,7 +6721,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7004,7 +6739,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7024,7 +6759,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7043,7 +6778,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7052,14 +6787,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7082,7 +6817,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7094,7 +6829,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7109,7 +6844,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7117,7 +6851,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-9-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-9-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7143,7 +6877,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7161,7 +6895,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7181,7 +6915,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7200,7 +6934,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7209,14 +6943,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7239,7 +6973,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7251,7 +6985,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7266,7 +7000,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7274,7 +7007,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-10-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-10-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7300,7 +7033,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7318,7 +7051,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7338,7 +7071,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7357,7 +7090,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7366,14 +7099,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7396,7 +7129,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7408,7 +7141,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7423,7 +7156,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7431,7 +7163,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-11-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-11-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7457,7 +7189,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7475,7 +7207,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7495,7 +7227,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7514,7 +7246,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7523,14 +7255,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7553,7 +7285,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7565,7 +7297,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7580,7 +7312,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7588,7 +7319,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-12-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-12-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7614,7 +7345,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7632,7 +7363,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7652,7 +7383,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7671,7 +7402,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7680,14 +7411,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7710,7 +7441,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7722,7 +7453,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7737,7 +7468,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7745,7 +7475,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-13-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-13-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7771,7 +7501,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7789,7 +7519,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7809,7 +7539,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7828,7 +7558,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7837,14 +7567,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -7867,7 +7597,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7879,7 +7609,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -7894,7 +7624,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -7902,7 +7631,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-14-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-14-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -7928,7 +7657,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -7946,7 +7675,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -7966,7 +7695,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -7985,7 +7714,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -7994,14 +7723,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8024,7 +7753,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8036,7 +7765,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8051,7 +7780,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8059,7 +7787,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-15-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-15-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8085,7 +7813,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8103,7 +7831,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8123,7 +7851,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8142,7 +7870,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8151,14 +7879,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8181,7 +7909,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8193,7 +7921,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8208,7 +7936,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8216,7 +7943,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-16-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-16-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8242,7 +7969,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8260,7 +7987,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8280,7 +8007,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8299,7 +8026,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8308,14 +8035,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8338,7 +8065,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8350,7 +8077,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8365,7 +8092,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8373,7 +8099,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-17-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-17-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8399,7 +8125,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8417,7 +8143,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8437,7 +8163,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8456,7 +8182,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8465,14 +8191,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8495,7 +8221,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8507,7 +8233,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8522,7 +8248,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8530,7 +8255,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-18-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-18-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8556,7 +8281,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8574,7 +8299,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8594,7 +8319,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8613,7 +8338,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8622,14 +8347,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8652,7 +8377,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8664,7 +8389,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8679,7 +8404,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8687,7 +8411,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-19-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-19-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8713,7 +8437,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8731,7 +8455,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8751,7 +8475,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8770,7 +8494,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8779,14 +8503,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8809,7 +8533,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8821,7 +8545,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8836,7 +8560,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -8844,7 +8567,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-20-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-20-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -8870,7 +8593,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -8888,7 +8611,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -8908,7 +8631,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -8927,7 +8650,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -8936,14 +8659,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -8966,7 +8689,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8978,7 +8701,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -8993,7 +8716,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9001,7 +8723,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-21-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-21-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9027,7 +8749,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9045,7 +8767,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9065,7 +8787,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9084,7 +8806,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9093,14 +8815,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9123,7 +8845,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9135,7 +8857,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9150,7 +8872,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9158,7 +8879,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-22-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-22-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9184,7 +8905,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9202,7 +8923,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9222,7 +8943,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9241,7 +8962,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9250,14 +8971,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9280,7 +9001,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9292,7 +9013,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9307,7 +9028,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9315,7 +9035,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-23-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-23-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9341,7 +9061,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9359,7 +9079,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9379,7 +9099,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9398,7 +9118,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9407,14 +9127,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9437,7 +9157,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9449,7 +9169,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9464,7 +9184,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9472,7 +9191,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-24-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-24-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9498,7 +9217,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9516,7 +9235,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9536,7 +9255,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9555,7 +9274,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9564,14 +9283,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9594,7 +9313,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9606,7 +9325,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9621,7 +9340,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9629,7 +9347,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreMKey-25-25-latest-mysql5.7-php7.0
+name: apiCoreMKey-25-25-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9655,7 +9373,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9673,7 +9391,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9693,7 +9411,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9712,7 +9430,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9721,14 +9439,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9751,7 +9469,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9763,7 +9481,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9778,7 +9496,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9786,7 +9503,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-1-master-mysql5.7-php7.0
+name: apiCoreUKey-25-1-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9812,7 +9529,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9830,7 +9547,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -9850,7 +9567,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -9869,7 +9586,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -9878,14 +9595,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -9908,7 +9625,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9920,7 +9637,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -9937,7 +9654,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -9945,7 +9661,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-2-master-mysql5.7-php7.0
+name: apiCoreUKey-25-2-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -9971,7 +9687,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -9989,7 +9705,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10009,7 +9725,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10028,7 +9744,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10037,14 +9753,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10067,7 +9783,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10079,7 +9795,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10096,7 +9812,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10104,7 +9819,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-3-master-mysql5.7-php7.0
+name: apiCoreUKey-25-3-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10130,7 +9845,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10148,7 +9863,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10168,7 +9883,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10187,7 +9902,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10196,14 +9911,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10226,7 +9941,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10238,7 +9953,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10255,7 +9970,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10263,7 +9977,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-4-master-mysql5.7-php7.0
+name: apiCoreUKey-25-4-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10289,7 +10003,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10307,7 +10021,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10327,7 +10041,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10346,7 +10060,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10355,14 +10069,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10385,7 +10099,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10397,7 +10111,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10414,7 +10128,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10422,7 +10135,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-5-master-mysql5.7-php7.0
+name: apiCoreUKey-25-5-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10448,7 +10161,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10466,7 +10179,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10486,7 +10199,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10505,7 +10218,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10514,14 +10227,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10544,7 +10257,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10556,7 +10269,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10573,7 +10286,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10581,7 +10293,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-6-master-mysql5.7-php7.0
+name: apiCoreUKey-25-6-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10607,7 +10319,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10625,7 +10337,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10645,7 +10357,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10664,7 +10376,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10673,14 +10385,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10703,7 +10415,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10715,7 +10427,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10732,7 +10444,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10740,7 +10451,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-7-master-mysql5.7-php7.0
+name: apiCoreUKey-25-7-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10766,7 +10477,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10784,7 +10495,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10804,7 +10515,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10823,7 +10534,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10832,14 +10543,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -10862,7 +10573,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10874,7 +10585,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -10891,7 +10602,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -10899,7 +10609,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-8-master-mysql5.7-php7.0
+name: apiCoreUKey-25-8-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -10925,7 +10635,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -10943,7 +10653,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -10963,7 +10673,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -10982,7 +10692,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -10991,14 +10701,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11021,7 +10731,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11033,7 +10743,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11050,7 +10760,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11058,7 +10767,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-9-master-mysql5.7-php7.0
+name: apiCoreUKey-25-9-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11084,7 +10793,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11102,7 +10811,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11122,7 +10831,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11141,7 +10850,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11150,14 +10859,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11180,7 +10889,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11192,7 +10901,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11209,7 +10918,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11217,7 +10925,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-10-master-mysql5.7-php7.0
+name: apiCoreUKey-25-10-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11243,7 +10951,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11261,7 +10969,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11281,7 +10989,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11300,7 +11008,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11309,14 +11017,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11339,7 +11047,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11351,7 +11059,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11368,7 +11076,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11376,7 +11083,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-11-master-mysql5.7-php7.0
+name: apiCoreUKey-25-11-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11402,7 +11109,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11420,7 +11127,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11440,7 +11147,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11459,7 +11166,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11468,14 +11175,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11498,7 +11205,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11510,7 +11217,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11527,7 +11234,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11535,7 +11241,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-12-master-mysql5.7-php7.0
+name: apiCoreUKey-25-12-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11561,7 +11267,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11579,7 +11285,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11599,7 +11305,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11618,7 +11324,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11627,14 +11333,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11657,7 +11363,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11669,7 +11375,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11686,7 +11392,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11694,7 +11399,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-13-master-mysql5.7-php7.0
+name: apiCoreUKey-25-13-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11720,7 +11425,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11738,7 +11443,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11758,7 +11463,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11777,7 +11482,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11786,14 +11491,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11816,7 +11521,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11828,7 +11533,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11845,7 +11550,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -11853,7 +11557,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-14-master-mysql5.7-php7.0
+name: apiCoreUKey-25-14-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -11879,7 +11583,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -11897,7 +11601,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -11917,7 +11621,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -11936,7 +11640,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -11945,14 +11649,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -11975,7 +11679,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -11987,7 +11691,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12004,7 +11708,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12012,7 +11715,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-15-master-mysql5.7-php7.0
+name: apiCoreUKey-25-15-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12038,7 +11741,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12056,7 +11759,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12076,7 +11779,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12095,7 +11798,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12104,14 +11807,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12134,7 +11837,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12146,7 +11849,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12163,7 +11866,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12171,7 +11873,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-16-master-mysql5.7-php7.0
+name: apiCoreUKey-25-16-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12197,7 +11899,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12215,7 +11917,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12235,7 +11937,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12254,7 +11956,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12263,14 +11965,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12293,7 +11995,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12305,7 +12007,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12322,7 +12024,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12330,7 +12031,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-17-master-mysql5.7-php7.0
+name: apiCoreUKey-25-17-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12356,7 +12057,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12374,7 +12075,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12394,7 +12095,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12413,7 +12114,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12422,14 +12123,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12452,7 +12153,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12464,7 +12165,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12481,7 +12182,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12489,7 +12189,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-18-master-mysql5.7-php7.0
+name: apiCoreUKey-25-18-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12515,7 +12215,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12533,7 +12233,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12553,7 +12253,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12572,7 +12272,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12581,14 +12281,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12611,7 +12311,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12623,7 +12323,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12640,7 +12340,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12648,7 +12347,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-19-master-mysql5.7-php7.0
+name: apiCoreUKey-25-19-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12674,7 +12373,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12692,7 +12391,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12712,7 +12411,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12731,7 +12430,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12740,14 +12439,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12770,7 +12469,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12782,7 +12481,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12799,7 +12498,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12807,7 +12505,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-20-master-mysql5.7-php7.0
+name: apiCoreUKey-25-20-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12833,7 +12531,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -12851,7 +12549,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -12871,7 +12569,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -12890,7 +12588,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -12899,14 +12597,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -12929,7 +12627,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12941,7 +12639,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -12958,7 +12656,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -12966,7 +12663,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-21-master-mysql5.7-php7.0
+name: apiCoreUKey-25-21-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -12992,7 +12689,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13010,7 +12707,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13030,7 +12727,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13049,7 +12746,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13058,14 +12755,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13088,7 +12785,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13100,7 +12797,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13117,7 +12814,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13125,7 +12821,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-22-master-mysql5.7-php7.0
+name: apiCoreUKey-25-22-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13151,7 +12847,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13169,7 +12865,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13189,7 +12885,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13208,7 +12904,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13217,14 +12913,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13247,7 +12943,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13259,7 +12955,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13276,7 +12972,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13284,7 +12979,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-23-master-mysql5.7-php7.0
+name: apiCoreUKey-25-23-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13310,7 +13005,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13328,7 +13023,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13348,7 +13043,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13367,7 +13062,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13376,14 +13071,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13406,7 +13101,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13418,7 +13113,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13435,7 +13130,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13443,7 +13137,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-24-master-mysql5.7-php7.0
+name: apiCoreUKey-25-24-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13469,7 +13163,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13487,7 +13181,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13507,7 +13201,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13526,7 +13220,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13535,14 +13229,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13565,7 +13259,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13577,7 +13271,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13594,7 +13288,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13602,7 +13295,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-25-master-mysql5.7-php7.0
+name: apiCoreUKey-25-25-master-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13628,7 +13321,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13646,7 +13339,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13666,7 +13359,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13685,7 +13378,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13694,14 +13387,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13724,7 +13417,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13736,7 +13429,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13753,7 +13446,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13761,7 +13453,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-1-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-1-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13787,7 +13479,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13805,7 +13497,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13825,7 +13517,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -13844,7 +13536,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -13853,14 +13545,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -13883,7 +13575,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13895,7 +13587,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -13910,7 +13602,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -13918,7 +13609,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-2-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-2-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -13944,7 +13635,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -13962,7 +13653,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -13982,7 +13673,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14001,7 +13692,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14010,14 +13701,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14040,7 +13731,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14052,7 +13743,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14067,7 +13758,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14075,7 +13765,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-3-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-3-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14101,7 +13791,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14119,7 +13809,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14139,7 +13829,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14158,7 +13848,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14167,14 +13857,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14197,7 +13887,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14209,7 +13899,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14224,7 +13914,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14232,7 +13921,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-4-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-4-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14258,7 +13947,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14276,7 +13965,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14296,7 +13985,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14315,7 +14004,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14324,14 +14013,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14354,7 +14043,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14366,7 +14055,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14381,7 +14070,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14389,7 +14077,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-5-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-5-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14415,7 +14103,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14433,7 +14121,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14453,7 +14141,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14472,7 +14160,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14481,14 +14169,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14511,7 +14199,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14523,7 +14211,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14538,7 +14226,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14546,7 +14233,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-6-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-6-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14572,7 +14259,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14590,7 +14277,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14610,7 +14297,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14629,7 +14316,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14638,14 +14325,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14668,7 +14355,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14680,7 +14367,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14695,7 +14382,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14703,7 +14389,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-7-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-7-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14729,7 +14415,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14747,7 +14433,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14767,7 +14453,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14786,7 +14472,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14795,14 +14481,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14825,7 +14511,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14837,7 +14523,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14852,7 +14538,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -14860,7 +14545,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-8-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-8-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -14886,7 +14571,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -14904,7 +14589,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -14924,7 +14609,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -14943,7 +14628,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -14952,14 +14637,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -14982,7 +14667,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -14994,7 +14679,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15009,7 +14694,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15017,7 +14701,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-9-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-9-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15043,7 +14727,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15061,7 +14745,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15081,7 +14765,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15100,7 +14784,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15109,14 +14793,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15139,7 +14823,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15151,7 +14835,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15166,7 +14850,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15174,7 +14857,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-10-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-10-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15200,7 +14883,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15218,7 +14901,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15238,7 +14921,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15257,7 +14940,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15266,14 +14949,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15296,7 +14979,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15308,7 +14991,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15323,7 +15006,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15331,7 +15013,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-11-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-11-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15357,7 +15039,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15375,7 +15057,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15395,7 +15077,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15414,7 +15096,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15423,14 +15105,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15453,7 +15135,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15465,7 +15147,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15480,7 +15162,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15488,7 +15169,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-12-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-12-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15514,7 +15195,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15532,7 +15213,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15552,7 +15233,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15571,7 +15252,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15580,14 +15261,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15610,7 +15291,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15622,7 +15303,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15637,7 +15318,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15645,7 +15325,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-13-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-13-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15671,7 +15351,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15689,7 +15369,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15709,7 +15389,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15728,7 +15408,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15737,14 +15417,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15767,7 +15447,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15779,7 +15459,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15794,7 +15474,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15802,7 +15481,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-14-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-14-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15828,7 +15507,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -15846,7 +15525,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -15866,7 +15545,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -15885,7 +15564,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -15894,14 +15573,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -15924,7 +15603,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15936,7 +15615,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -15951,7 +15630,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -15959,7 +15637,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-15-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-15-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -15985,7 +15663,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16003,7 +15681,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16023,7 +15701,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16042,7 +15720,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16051,14 +15729,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16081,7 +15759,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16093,7 +15771,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16108,7 +15786,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16116,7 +15793,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-16-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-16-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16142,7 +15819,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16160,7 +15837,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16180,7 +15857,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16199,7 +15876,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16208,14 +15885,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16238,7 +15915,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16250,7 +15927,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16265,7 +15942,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16273,7 +15949,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-17-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-17-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16299,7 +15975,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16317,7 +15993,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16337,7 +16013,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16356,7 +16032,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16365,14 +16041,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16395,7 +16071,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16407,7 +16083,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16422,7 +16098,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16430,7 +16105,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-18-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-18-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16456,7 +16131,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16474,7 +16149,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16494,7 +16169,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16513,7 +16188,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16522,14 +16197,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16552,7 +16227,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16564,7 +16239,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16579,7 +16254,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16587,7 +16261,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-19-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-19-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16613,7 +16287,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16631,7 +16305,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16651,7 +16325,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16670,7 +16344,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16679,14 +16353,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16709,7 +16383,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16721,7 +16395,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16736,7 +16410,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16744,7 +16417,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-20-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-20-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16770,7 +16443,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16788,7 +16461,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16808,7 +16481,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16827,7 +16500,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16836,14 +16509,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -16866,7 +16539,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16878,7 +16551,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -16893,7 +16566,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -16901,7 +16573,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-21-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-21-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -16927,7 +16599,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -16945,7 +16617,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -16965,7 +16637,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -16984,7 +16656,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -16993,14 +16665,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17023,7 +16695,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17035,7 +16707,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17050,7 +16722,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -17058,7 +16729,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-22-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-22-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -17084,7 +16755,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17102,7 +16773,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17122,7 +16793,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17141,7 +16812,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -17150,14 +16821,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17180,7 +16851,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17192,7 +16863,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17207,7 +16878,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -17215,7 +16885,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-23-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-23-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -17241,7 +16911,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17259,7 +16929,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17279,7 +16949,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17298,7 +16968,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -17307,14 +16977,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17337,7 +17007,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17349,7 +17019,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17364,7 +17034,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -17372,7 +17041,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-24-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-24-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -17398,7 +17067,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17416,7 +17085,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17436,7 +17105,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17455,7 +17124,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -17464,14 +17133,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17494,7 +17163,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17506,7 +17175,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17521,7 +17190,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -17529,7 +17197,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiCoreUKey-25-25-latest-mysql5.7-php7.0
+name: apiCoreUKey-25-25-latest-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -17555,7 +17223,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17573,7 +17241,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17593,7 +17261,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17612,7 +17280,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -17621,14 +17289,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -17651,7 +17319,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17663,7 +17331,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -17678,7 +17346,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -17686,7 +17353,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-1-master-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-1-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -17712,7 +17379,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -17730,7 +17397,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -17750,7 +17417,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -17769,7 +17436,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -17778,4364 +17445,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 1
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-2-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 2
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-3-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 3
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-4-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 4
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-5-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 5
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-6-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 6
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-7-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 7
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-8-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 8
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-9-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 9
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-10-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 10
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-11-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 11
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-12-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 12
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-13-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 13
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-14-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 14
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-15-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 15
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-16-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 16
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-17-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 17
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-18-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 18
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-19-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 19
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-20-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 20
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-21-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 21
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-22-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 22
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-23-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 23
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-24-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 24
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-25-master-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: daily-master-qa
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: daily-master-qa
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - touch /var/www/owncloud/saved-settings.sh
-  - . /var/www/owncloud/saved-settings.sh
-  - make test-acceptance-core-webui
-  environment:
-    BROWSER: chrome
-    DIVIDE_INTO_NUM_PARTS: 25
-    ENCRYPTION_TYPE: masterkey
-    MAILHOG_HOST: email
-    PLATFORM: Linux
-    RUN_PART: 25
-    SELENIUM_HOST: selenium
-    SELENIUM_PORT: 4444
-    TEST_SERVER_URL: http://server
-
-services:
-- name: mysql
-  pull: always
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: owncloud
-    MYSQL_PASSWORD: owncloud
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: owncloud
-
-- name: selenium
-  pull: always
-  image: selenium/standalone-chrome-debug:3.141.59-oxygen
-  environment:
-    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
-
-- name: email
-  pull: always
-  image: mailhog/mailhog
-
-- name: server
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/server
-
-- name: federated
-  pull: always
-  image: owncloudci/php:7.0
-  command:
-  - /usr/local/bin/apachectl
-  - -e
-  - debug
-  - -D
-  - FOREGROUND
-  environment:
-    APACHE_WEBROOT: /var/www/owncloud/federated
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
-depends_on:
-- coding-standard-php7.0
-- coding-standard-php7.1
-- coding-standard-php7.2
-- coding-standard-php7.3
-
----
-kind: pipeline
-type: docker
-name: webUIcoreMKey-25-1-latest-chrome-mysql5.7-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: testrunner/apps/encryption
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: mysql
-    db_name: owncloud
-    db_password: owncloud
-    db_type: mysql
-    db_username: owncloud
-    exclude: apps/encryption
-    version: latest
-
-- name: install-testrunner
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - mkdir /tmp/testrunner
-  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
-  - rsync -aIX /tmp/testrunner /var/www/owncloud
-  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps vendor-bin-deps
-
-- name: install-federation
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/federated
-    version: latest
-
-- name: configure-federation
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-  - cd /var/www/owncloud/federated
-  - php occ a:l
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=federated
-  - php occ log:manage --level 2
-  - php occ config:list
-
-- name: owncloud-log-federated
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/federated/data/owncloud.log
-
-- name: setup-server-encryption
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ a:l
-  - php occ a:e encryption
-  - php occ a:e testing
-  - php occ a:l
-  - php occ config:system:set trusted_domains 1 --value=server
-  - php occ log:manage --level 2
-
-- name: owncloud-log-server
-  pull: always
-  image: owncloud/ubuntu:18.04
-  detach: true
-  commands:
-  - tail -f /var/www/owncloud/server/data/owncloud.log
-
-- name: configure-app
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - cd /var/www/owncloud/server
-  - php occ encryption:enable
-  - php occ encryption:select-encryption-type masterkey --yes
-  - php occ config:list
-
-- name: fix-permissions
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - chown -R www-data /var/www/owncloud/server
-  - chown -R www-data /var/www/owncloud/federated
-
-- name: acceptance-tests
-  pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -22173,7 +17490,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22185,7 +17502,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22196,11 +17513,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -22208,7 +17526,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-2-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-2-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -22230,11 +17548,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -22248,11 +17566,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -22272,7 +17590,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -22291,7 +17609,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -22300,14 +17618,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -22345,7 +17663,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22357,7 +17675,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22368,11 +17686,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -22380,7 +17699,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-3-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-3-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -22402,11 +17721,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -22420,11 +17739,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -22444,7 +17763,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -22463,7 +17782,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -22472,14 +17791,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -22517,7 +17836,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22529,7 +17848,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22540,11 +17859,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -22552,7 +17872,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-4-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-4-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -22574,11 +17894,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -22592,11 +17912,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -22616,7 +17936,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -22635,7 +17955,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -22644,14 +17964,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -22689,7 +18009,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22701,7 +18021,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22712,11 +18032,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -22724,7 +18045,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-5-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-5-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -22746,11 +18067,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -22764,11 +18085,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -22788,7 +18109,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -22807,7 +18128,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -22816,14 +18137,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -22861,7 +18182,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22873,7 +18194,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -22884,11 +18205,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -22896,7 +18218,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-6-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-6-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -22918,11 +18240,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -22936,11 +18258,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -22960,7 +18282,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -22979,7 +18301,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -22988,14 +18310,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23033,7 +18355,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23045,7 +18367,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23056,11 +18378,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23068,7 +18391,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-7-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-7-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23090,11 +18413,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23108,11 +18431,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23132,7 +18455,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -23151,7 +18474,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -23160,14 +18483,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23205,7 +18528,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23217,7 +18540,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23228,11 +18551,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23240,7 +18564,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-8-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-8-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23262,11 +18586,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23280,11 +18604,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23304,7 +18628,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -23323,7 +18647,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -23332,14 +18656,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23377,7 +18701,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23389,7 +18713,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23400,11 +18724,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23412,7 +18737,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-9-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-9-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23434,11 +18759,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23452,11 +18777,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23476,7 +18801,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -23495,7 +18820,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -23504,14 +18829,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23549,7 +18874,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23561,7 +18886,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23572,11 +18897,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23584,7 +18910,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-10-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-10-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23606,11 +18932,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23624,11 +18950,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23648,7 +18974,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -23667,7 +18993,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -23676,14 +19002,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23721,7 +19047,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23733,7 +19059,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23744,11 +19070,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23756,7 +19083,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-11-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-11-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23778,11 +19105,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23796,11 +19123,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23820,7 +19147,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -23839,7 +19166,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -23848,14 +19175,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -23893,7 +19220,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23905,7 +19232,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -23916,11 +19243,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -23928,7 +19256,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-12-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-12-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -23950,11 +19278,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -23968,11 +19296,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -23992,7 +19320,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24011,7 +19339,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24020,14 +19348,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24065,7 +19393,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24077,7 +19405,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24088,11 +19416,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24100,7 +19429,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-13-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-13-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24122,11 +19451,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -24140,11 +19469,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -24164,7 +19493,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24183,7 +19512,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24192,14 +19521,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24237,7 +19566,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24249,7 +19578,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24260,11 +19589,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24272,7 +19602,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-14-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-14-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24294,11 +19624,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -24312,11 +19642,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -24336,7 +19666,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24355,7 +19685,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24364,14 +19694,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24409,7 +19739,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24421,7 +19751,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24432,11 +19762,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24444,7 +19775,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-15-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-15-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24466,11 +19797,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -24484,11 +19815,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -24508,7 +19839,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24527,7 +19858,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24536,14 +19867,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24581,7 +19912,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24593,7 +19924,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24604,11 +19935,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24616,7 +19948,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-16-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-16-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24638,11 +19970,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -24656,11 +19988,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -24680,7 +20012,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24699,7 +20031,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24708,14 +20040,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24753,7 +20085,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24765,7 +20097,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24776,11 +20108,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24788,7 +20121,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-17-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-17-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24810,11 +20143,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -24828,11 +20161,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -24852,7 +20185,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -24871,7 +20204,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -24880,14 +20213,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -24925,7 +20258,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24937,7 +20270,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -24948,11 +20281,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -24960,7 +20294,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-18-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-18-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -24982,11 +20316,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25000,11 +20334,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25024,7 +20358,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25043,7 +20377,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25052,14 +20386,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25097,7 +20431,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25109,7 +20443,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25120,11 +20454,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25132,7 +20467,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-19-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-19-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -25154,11 +20489,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25172,11 +20507,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25196,7 +20531,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25215,7 +20550,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25224,14 +20559,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25269,7 +20604,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25281,7 +20616,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25292,11 +20627,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25304,7 +20640,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-20-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-20-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -25326,11 +20662,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25344,11 +20680,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25368,7 +20704,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25387,7 +20723,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25396,14 +20732,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25441,7 +20777,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25453,7 +20789,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25464,11 +20800,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25476,7 +20813,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-21-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-21-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -25498,11 +20835,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25516,11 +20853,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25540,7 +20877,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25559,7 +20896,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25568,14 +20905,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25613,7 +20950,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25625,7 +20962,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25636,11 +20973,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25648,7 +20986,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-22-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-22-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -25670,11 +21008,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25688,11 +21026,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25712,7 +21050,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25731,7 +21069,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25740,14 +21078,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25785,7 +21123,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25797,7 +21135,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25808,11 +21146,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25820,7 +21159,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-23-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-23-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -25842,11 +21181,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -25860,11 +21199,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -25884,7 +21223,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -25903,7 +21242,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -25912,14 +21251,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -25957,7 +21296,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25969,7 +21308,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -25980,11 +21319,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -25992,7 +21332,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-24-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-24-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26014,11 +21354,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26032,11 +21372,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26056,7 +21396,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26075,7 +21415,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26084,14 +21424,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26129,7 +21469,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26141,7 +21481,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26152,11 +21492,12 @@ services:
     APACHE_WEBROOT: /var/www/owncloud/federated
 
 trigger:
-  cron:
-  - nightly
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -26164,7 +21505,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreMKey-25-25-latest-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-25-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26186,11 +21527,11 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/encryption
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26204,11 +21545,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26228,7 +21569,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26247,7 +21588,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26256,14 +21597,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26301,7 +21642,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26313,7 +21654,180 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-1-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 1
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26328,7 +21842,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -26336,7 +21849,4111 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-1-master-chrome-mysql5.7-php7.0
+name: webUIcoreMKey-25-2-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 2
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-3-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 3
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-4-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 4
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-5-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 5
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-6-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 6
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-7-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 7
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-8-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 8
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-9-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 9
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-10-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 10
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-11-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 11
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-12-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 12
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-13-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 13
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-14-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 14
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-15-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 15
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-16-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 16
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-17-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 17
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-18-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 18
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-19-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 19
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-20-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 20
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-21-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 21
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-22-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 22
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-23-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 23
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-24-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 24
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreMKey-25-25-latest-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: latest
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BROWSER: chrome
+    DIVIDE_INTO_NUM_PARTS: 25
+    ENCRYPTION_TYPE: masterkey
+    MAILHOG_HOST: email
+    PLATFORM: Linux
+    RUN_PART: 25
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: email
+  pull: always
+  image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  cron:
+  - nightly
+
+depends_on:
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIcoreUKey-25-1-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26362,7 +25979,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26380,7 +25997,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26400,7 +26017,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26419,7 +26036,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26428,14 +26045,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26473,7 +26090,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26485,7 +26102,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26502,7 +26119,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -26510,7 +26126,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-2-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-2-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26536,7 +26152,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26554,7 +26170,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26574,7 +26190,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26593,7 +26209,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26602,14 +26218,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26647,7 +26263,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26659,7 +26275,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26676,7 +26292,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -26684,7 +26299,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-3-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-3-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26710,7 +26325,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26728,7 +26343,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26748,7 +26363,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26767,7 +26382,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26776,14 +26391,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26821,7 +26436,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26833,7 +26448,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -26850,7 +26465,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -26858,7 +26472,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-4-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-4-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -26884,7 +26498,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -26902,7 +26516,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -26922,7 +26536,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -26941,7 +26555,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -26950,14 +26564,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -26995,7 +26609,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27007,7 +26621,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27024,7 +26638,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27032,7 +26645,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-5-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-5-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27058,7 +26671,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27076,7 +26689,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27096,7 +26709,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27115,7 +26728,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27124,14 +26737,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -27169,7 +26782,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27181,7 +26794,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27198,7 +26811,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27206,7 +26818,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-6-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-6-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27232,7 +26844,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27250,7 +26862,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27270,7 +26882,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27289,7 +26901,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27298,14 +26910,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -27343,7 +26955,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27355,7 +26967,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27372,7 +26984,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27380,7 +26991,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-7-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-7-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27406,7 +27017,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27424,7 +27035,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27444,7 +27055,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27463,7 +27074,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27472,14 +27083,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -27517,7 +27128,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27529,7 +27140,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27546,7 +27157,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27554,7 +27164,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-8-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-8-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27580,7 +27190,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27598,7 +27208,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27618,7 +27228,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27637,7 +27247,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27646,14 +27256,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -27691,7 +27301,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27703,7 +27313,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27720,7 +27330,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27728,7 +27337,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-9-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-9-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27754,7 +27363,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27772,7 +27381,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27792,7 +27401,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27811,7 +27420,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27820,14 +27429,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -27865,7 +27474,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27877,7 +27486,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -27894,7 +27503,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -27902,7 +27510,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-10-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-10-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -27928,7 +27536,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -27946,7 +27554,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -27966,7 +27574,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -27985,7 +27593,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -27994,14 +27602,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28039,7 +27647,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28051,7 +27659,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28068,7 +27676,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28076,7 +27683,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-11-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-11-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28102,7 +27709,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28120,7 +27727,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -28140,7 +27747,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -28159,7 +27766,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -28168,14 +27775,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28213,7 +27820,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28225,7 +27832,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28242,7 +27849,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28250,7 +27856,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-12-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-12-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28276,7 +27882,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28294,7 +27900,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -28314,7 +27920,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -28333,7 +27939,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -28342,14 +27948,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28387,7 +27993,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28399,7 +28005,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28416,7 +28022,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28424,7 +28029,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-13-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-13-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28450,7 +28055,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28468,7 +28073,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -28488,7 +28093,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -28507,7 +28112,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -28516,14 +28121,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28561,7 +28166,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28573,7 +28178,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28590,7 +28195,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28598,7 +28202,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-14-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-14-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28624,7 +28228,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28642,7 +28246,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -28662,7 +28266,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -28681,7 +28285,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -28690,14 +28294,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28735,7 +28339,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28747,7 +28351,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28764,7 +28368,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28772,7 +28375,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-15-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-15-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28798,7 +28401,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28816,7 +28419,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -28836,7 +28439,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -28855,7 +28458,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -28864,14 +28467,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -28909,7 +28512,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28921,7 +28524,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -28938,7 +28541,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -28946,7 +28548,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-16-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-16-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -28972,7 +28574,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -28990,7 +28592,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29010,7 +28612,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29029,7 +28631,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29038,14 +28640,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29083,7 +28685,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29095,7 +28697,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29112,7 +28714,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29120,7 +28721,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-17-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-17-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -29146,7 +28747,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -29164,7 +28765,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29184,7 +28785,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29203,7 +28804,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29212,14 +28813,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29257,7 +28858,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29269,7 +28870,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29286,7 +28887,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29294,7 +28894,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-18-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-18-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -29320,7 +28920,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -29338,7 +28938,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29358,7 +28958,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29377,7 +28977,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29386,14 +28986,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29431,7 +29031,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29443,7 +29043,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29460,7 +29060,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29468,7 +29067,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-19-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-19-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -29494,7 +29093,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -29512,7 +29111,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29532,7 +29131,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29551,7 +29150,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29560,14 +29159,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29605,7 +29204,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29617,7 +29216,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29634,7 +29233,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29642,7 +29240,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-20-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-20-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -29668,7 +29266,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -29686,7 +29284,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29706,7 +29304,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29725,7 +29323,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29734,14 +29332,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29779,7 +29377,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29791,7 +29389,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29808,7 +29406,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29816,7 +29413,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-21-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-21-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -29842,7 +29439,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -29860,7 +29457,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -29880,7 +29477,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -29899,7 +29496,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -29908,14 +29505,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -29953,7 +29550,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29965,7 +29562,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -29982,7 +29579,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -29990,7 +29586,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-22-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-22-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30016,7 +29612,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30034,7 +29630,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30054,7 +29650,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30073,7 +29669,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30082,14 +29678,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30127,7 +29723,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30139,7 +29735,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30156,7 +29752,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -30164,7 +29759,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-23-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-23-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30190,7 +29785,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30208,7 +29803,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30228,7 +29823,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30247,7 +29842,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30256,14 +29851,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30301,7 +29896,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30313,7 +29908,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30330,7 +29925,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -30338,7 +29932,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-24-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-24-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30364,7 +29958,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30382,7 +29976,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30402,7 +29996,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30421,7 +30015,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30430,14 +30024,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30475,7 +30069,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30487,7 +30081,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30504,7 +30098,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -30512,7 +30105,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-25-master-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-25-master-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30538,7 +30131,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30556,7 +30149,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30576,7 +30169,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30595,7 +30188,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30604,14 +30197,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30649,7 +30242,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30661,7 +30254,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30678,7 +30271,6 @@ trigger:
   - refs/heads/master
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -30686,7 +30278,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-1-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-1-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30712,7 +30304,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30730,7 +30322,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30750,7 +30342,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30769,7 +30361,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30778,14 +30370,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30823,7 +30415,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30835,7 +30427,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -30850,7 +30442,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -30858,7 +30449,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-2-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-2-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -30884,7 +30475,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -30902,7 +30493,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -30922,7 +30513,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -30941,7 +30532,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -30950,14 +30541,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -30995,7 +30586,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31007,7 +30598,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31022,7 +30613,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31030,7 +30620,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-3-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-3-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31056,7 +30646,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31074,7 +30664,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31094,7 +30684,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31113,7 +30703,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31122,14 +30712,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -31167,7 +30757,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31179,7 +30769,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31194,7 +30784,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31202,7 +30791,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-4-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-4-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31228,7 +30817,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31246,7 +30835,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31266,7 +30855,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31285,7 +30874,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31294,14 +30883,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -31339,7 +30928,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31351,7 +30940,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31366,7 +30955,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31374,7 +30962,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-5-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-5-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31400,7 +30988,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31418,7 +31006,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31438,7 +31026,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31457,7 +31045,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31466,14 +31054,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -31511,7 +31099,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31523,7 +31111,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31538,7 +31126,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31546,7 +31133,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-6-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-6-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31572,7 +31159,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31590,7 +31177,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31610,7 +31197,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31629,7 +31216,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31638,14 +31225,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -31683,7 +31270,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31695,7 +31282,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31710,7 +31297,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31718,7 +31304,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-7-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-7-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31744,7 +31330,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31762,7 +31348,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31782,7 +31368,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31801,7 +31387,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31810,14 +31396,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -31855,7 +31441,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31867,7 +31453,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -31882,7 +31468,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -31890,7 +31475,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-8-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-8-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -31916,7 +31501,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -31934,7 +31519,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -31954,7 +31539,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -31973,7 +31558,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -31982,14 +31567,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32027,7 +31612,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32039,7 +31624,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32054,7 +31639,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32062,7 +31646,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-9-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-9-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32088,7 +31672,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32106,7 +31690,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32126,7 +31710,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -32145,7 +31729,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -32154,14 +31738,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32199,7 +31783,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32211,7 +31795,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32226,7 +31810,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32234,7 +31817,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-10-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-10-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32260,7 +31843,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32278,7 +31861,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32298,7 +31881,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -32317,7 +31900,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -32326,14 +31909,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32371,7 +31954,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32383,7 +31966,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32398,7 +31981,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32406,7 +31988,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-11-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-11-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32432,7 +32014,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32450,7 +32032,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32470,7 +32052,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -32489,7 +32071,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -32498,14 +32080,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32543,7 +32125,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32555,7 +32137,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32570,7 +32152,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32578,7 +32159,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-12-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-12-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32604,7 +32185,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32622,7 +32203,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32642,7 +32223,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -32661,7 +32242,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -32670,14 +32251,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32715,7 +32296,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32727,7 +32308,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32742,7 +32323,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32750,7 +32330,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-13-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-13-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32776,7 +32356,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32794,7 +32374,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32814,7 +32394,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -32833,7 +32413,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -32842,14 +32422,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -32887,7 +32467,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32899,7 +32479,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -32914,7 +32494,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -32922,7 +32501,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-14-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-14-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -32948,7 +32527,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -32966,7 +32545,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -32986,7 +32565,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33005,7 +32584,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33014,14 +32593,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33059,7 +32638,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33071,7 +32650,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33086,7 +32665,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33094,7 +32672,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-15-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-15-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33120,7 +32698,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33138,7 +32716,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -33158,7 +32736,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33177,7 +32755,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33186,14 +32764,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33231,7 +32809,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33243,7 +32821,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33258,7 +32836,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33266,7 +32843,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-16-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-16-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33292,7 +32869,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33310,7 +32887,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -33330,7 +32907,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33349,7 +32926,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33358,14 +32935,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33403,7 +32980,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33415,7 +32992,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33430,7 +33007,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33438,7 +33014,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-17-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-17-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33464,7 +33040,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33482,7 +33058,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -33502,7 +33078,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33521,7 +33097,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33530,14 +33106,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33575,7 +33151,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33587,7 +33163,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33602,7 +33178,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33610,7 +33185,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-18-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-18-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33636,7 +33211,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33654,7 +33229,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -33674,7 +33249,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33693,7 +33268,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33702,14 +33277,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33747,7 +33322,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33759,7 +33334,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33774,7 +33349,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33782,7 +33356,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-19-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-19-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33808,7 +33382,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33826,7 +33400,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -33846,7 +33420,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -33865,7 +33439,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -33874,14 +33448,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -33919,7 +33493,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33931,7 +33505,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -33946,7 +33520,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -33954,7 +33527,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-20-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-20-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -33980,7 +33553,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -33998,7 +33571,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34018,7 +33591,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34037,7 +33610,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34046,14 +33619,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34091,7 +33664,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34103,7 +33676,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34118,7 +33691,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -34126,7 +33698,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-21-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-21-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -34152,7 +33724,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -34170,7 +33742,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34190,7 +33762,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34209,7 +33781,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34218,14 +33790,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34263,7 +33835,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34275,7 +33847,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34290,7 +33862,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -34298,7 +33869,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-22-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-22-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -34324,7 +33895,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -34342,7 +33913,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34362,7 +33933,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34381,7 +33952,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34390,14 +33961,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34435,7 +34006,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34447,7 +34018,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34462,7 +34033,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -34470,7 +34040,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-23-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-23-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -34496,7 +34066,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -34514,7 +34084,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34534,7 +34104,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34553,7 +34123,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34562,14 +34132,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34607,7 +34177,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34619,7 +34189,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34634,7 +34204,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -34642,7 +34211,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-24-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-24-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -34668,7 +34237,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -34686,7 +34255,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34706,7 +34275,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34725,7 +34294,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34734,14 +34303,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34779,7 +34348,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34791,7 +34360,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34806,7 +34375,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -34814,7 +34382,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIcoreUKey-25-25-latest-chrome-mysql5.7-php7.0
+name: webUIcoreUKey-25-25-latest-chrome-mysql5.7-php7.1
 
 platform:
   os: linux
@@ -34840,7 +34408,7 @@ steps:
 
 - name: install-testrunner
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - mkdir /tmp/testrunner
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
@@ -34858,7 +34426,7 @@ steps:
 
 - name: configure-federation
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
   - cd /var/www/owncloud/federated
@@ -34878,7 +34446,7 @@ steps:
 
 - name: setup-server-encryption
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ a:l
@@ -34897,7 +34465,7 @@ steps:
 
 - name: configure-app
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
   - php occ encryption:enable
@@ -34906,14 +34474,14 @@ steps:
 
 - name: fix-permissions
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - chown -R www-data /var/www/owncloud/server
   - chown -R www-data /var/www/owncloud/federated
 
 - name: acceptance-tests
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   commands:
   - touch /var/www/owncloud/saved-settings.sh
   - . /var/www/owncloud/saved-settings.sh
@@ -34951,7 +34519,7 @@ services:
 
 - name: server
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34963,7 +34531,7 @@ services:
 
 - name: federated
   pull: always
-  image: owncloudci/php:7.0
+  image: owncloudci/php:7.1
   command:
   - /usr/local/bin/apachectl
   - -e
@@ -34978,7 +34546,6 @@ trigger:
   - nightly
 
 depends_on:
-- coding-standard-php7.0
 - coding-standard-php7.1
 - coding-standard-php7.2
 - coding-standard-php7.3
@@ -35016,222 +34583,219 @@ depends_on:
 - phpunit-php7.1-sqlite
 - phpunit-php7.1-mysql5.5
 - phpunit-php7.1-postgres9.4
-- phpunit-php7.0-sqlite
-- phpunit-php7.0-mysql5.5
-- phpunit-php7.0-postgres9.4
 - phpunit-php7.2-sqlite
 - phpunit-php7.2-mysql5.5
 - phpunit-php7.2-postgres9.4
 - phpunit-php7.3-sqlite
 - phpunit-php7.3-mysql5.5
 - phpunit-php7.3-postgres9.4
-- cliEncryption-master-mysql5.5-php7.0
-- cliEncryption-master-postgres9.4-php7.0
-- cliEncryption-latest-mysql5.5-php7.0
-- cliEncryption-latest-postgres9.4-php7.0
-- webUIMasterKey-master-chrome-mysql5.5-php7.0
-- webUIMasterKey-latest-chrome-mysql5.5-php7.0
-- webUIUserKeys-master-chrome-mysql5.5-php7.0
-- webUIUserKeys-latest-chrome-mysql5.5-php7.0
-- apiCoreMKey-25-1-master-mysql5.7-php7.0
-- apiCoreMKey-25-2-master-mysql5.7-php7.0
-- apiCoreMKey-25-3-master-mysql5.7-php7.0
-- apiCoreMKey-25-4-master-mysql5.7-php7.0
-- apiCoreMKey-25-5-master-mysql5.7-php7.0
-- apiCoreMKey-25-6-master-mysql5.7-php7.0
-- apiCoreMKey-25-7-master-mysql5.7-php7.0
-- apiCoreMKey-25-8-master-mysql5.7-php7.0
-- apiCoreMKey-25-9-master-mysql5.7-php7.0
-- apiCoreMKey-25-10-master-mysql5.7-php7.0
-- apiCoreMKey-25-11-master-mysql5.7-php7.0
-- apiCoreMKey-25-12-master-mysql5.7-php7.0
-- apiCoreMKey-25-13-master-mysql5.7-php7.0
-- apiCoreMKey-25-14-master-mysql5.7-php7.0
-- apiCoreMKey-25-15-master-mysql5.7-php7.0
-- apiCoreMKey-25-16-master-mysql5.7-php7.0
-- apiCoreMKey-25-17-master-mysql5.7-php7.0
-- apiCoreMKey-25-18-master-mysql5.7-php7.0
-- apiCoreMKey-25-19-master-mysql5.7-php7.0
-- apiCoreMKey-25-20-master-mysql5.7-php7.0
-- apiCoreMKey-25-21-master-mysql5.7-php7.0
-- apiCoreMKey-25-22-master-mysql5.7-php7.0
-- apiCoreMKey-25-23-master-mysql5.7-php7.0
-- apiCoreMKey-25-24-master-mysql5.7-php7.0
-- apiCoreMKey-25-25-master-mysql5.7-php7.0
-- apiCoreMKey-25-1-latest-mysql5.7-php7.0
-- apiCoreMKey-25-2-latest-mysql5.7-php7.0
-- apiCoreMKey-25-3-latest-mysql5.7-php7.0
-- apiCoreMKey-25-4-latest-mysql5.7-php7.0
-- apiCoreMKey-25-5-latest-mysql5.7-php7.0
-- apiCoreMKey-25-6-latest-mysql5.7-php7.0
-- apiCoreMKey-25-7-latest-mysql5.7-php7.0
-- apiCoreMKey-25-8-latest-mysql5.7-php7.0
-- apiCoreMKey-25-9-latest-mysql5.7-php7.0
-- apiCoreMKey-25-10-latest-mysql5.7-php7.0
-- apiCoreMKey-25-11-latest-mysql5.7-php7.0
-- apiCoreMKey-25-12-latest-mysql5.7-php7.0
-- apiCoreMKey-25-13-latest-mysql5.7-php7.0
-- apiCoreMKey-25-14-latest-mysql5.7-php7.0
-- apiCoreMKey-25-15-latest-mysql5.7-php7.0
-- apiCoreMKey-25-16-latest-mysql5.7-php7.0
-- apiCoreMKey-25-17-latest-mysql5.7-php7.0
-- apiCoreMKey-25-18-latest-mysql5.7-php7.0
-- apiCoreMKey-25-19-latest-mysql5.7-php7.0
-- apiCoreMKey-25-20-latest-mysql5.7-php7.0
-- apiCoreMKey-25-21-latest-mysql5.7-php7.0
-- apiCoreMKey-25-22-latest-mysql5.7-php7.0
-- apiCoreMKey-25-23-latest-mysql5.7-php7.0
-- apiCoreMKey-25-24-latest-mysql5.7-php7.0
-- apiCoreMKey-25-25-latest-mysql5.7-php7.0
-- apiCoreUKey-25-1-master-mysql5.7-php7.0
-- apiCoreUKey-25-2-master-mysql5.7-php7.0
-- apiCoreUKey-25-3-master-mysql5.7-php7.0
-- apiCoreUKey-25-4-master-mysql5.7-php7.0
-- apiCoreUKey-25-5-master-mysql5.7-php7.0
-- apiCoreUKey-25-6-master-mysql5.7-php7.0
-- apiCoreUKey-25-7-master-mysql5.7-php7.0
-- apiCoreUKey-25-8-master-mysql5.7-php7.0
-- apiCoreUKey-25-9-master-mysql5.7-php7.0
-- apiCoreUKey-25-10-master-mysql5.7-php7.0
-- apiCoreUKey-25-11-master-mysql5.7-php7.0
-- apiCoreUKey-25-12-master-mysql5.7-php7.0
-- apiCoreUKey-25-13-master-mysql5.7-php7.0
-- apiCoreUKey-25-14-master-mysql5.7-php7.0
-- apiCoreUKey-25-15-master-mysql5.7-php7.0
-- apiCoreUKey-25-16-master-mysql5.7-php7.0
-- apiCoreUKey-25-17-master-mysql5.7-php7.0
-- apiCoreUKey-25-18-master-mysql5.7-php7.0
-- apiCoreUKey-25-19-master-mysql5.7-php7.0
-- apiCoreUKey-25-20-master-mysql5.7-php7.0
-- apiCoreUKey-25-21-master-mysql5.7-php7.0
-- apiCoreUKey-25-22-master-mysql5.7-php7.0
-- apiCoreUKey-25-23-master-mysql5.7-php7.0
-- apiCoreUKey-25-24-master-mysql5.7-php7.0
-- apiCoreUKey-25-25-master-mysql5.7-php7.0
-- apiCoreUKey-25-1-latest-mysql5.7-php7.0
-- apiCoreUKey-25-2-latest-mysql5.7-php7.0
-- apiCoreUKey-25-3-latest-mysql5.7-php7.0
-- apiCoreUKey-25-4-latest-mysql5.7-php7.0
-- apiCoreUKey-25-5-latest-mysql5.7-php7.0
-- apiCoreUKey-25-6-latest-mysql5.7-php7.0
-- apiCoreUKey-25-7-latest-mysql5.7-php7.0
-- apiCoreUKey-25-8-latest-mysql5.7-php7.0
-- apiCoreUKey-25-9-latest-mysql5.7-php7.0
-- apiCoreUKey-25-10-latest-mysql5.7-php7.0
-- apiCoreUKey-25-11-latest-mysql5.7-php7.0
-- apiCoreUKey-25-12-latest-mysql5.7-php7.0
-- apiCoreUKey-25-13-latest-mysql5.7-php7.0
-- apiCoreUKey-25-14-latest-mysql5.7-php7.0
-- apiCoreUKey-25-15-latest-mysql5.7-php7.0
-- apiCoreUKey-25-16-latest-mysql5.7-php7.0
-- apiCoreUKey-25-17-latest-mysql5.7-php7.0
-- apiCoreUKey-25-18-latest-mysql5.7-php7.0
-- apiCoreUKey-25-19-latest-mysql5.7-php7.0
-- apiCoreUKey-25-20-latest-mysql5.7-php7.0
-- apiCoreUKey-25-21-latest-mysql5.7-php7.0
-- apiCoreUKey-25-22-latest-mysql5.7-php7.0
-- apiCoreUKey-25-23-latest-mysql5.7-php7.0
-- apiCoreUKey-25-24-latest-mysql5.7-php7.0
-- apiCoreUKey-25-25-latest-mysql5.7-php7.0
-- webUIcoreMKey-25-1-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-2-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-3-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-4-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-5-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-6-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-7-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-8-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-9-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-10-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-11-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-12-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-13-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-14-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-15-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-16-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-17-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-18-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-19-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-20-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-21-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-22-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-23-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-24-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-25-master-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-1-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-2-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-3-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-4-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-5-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-6-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-7-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-8-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-9-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-10-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-11-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-12-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-13-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-14-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-15-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-16-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-17-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-18-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-19-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-20-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-21-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-22-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-23-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-24-latest-chrome-mysql5.7-php7.0
-- webUIcoreMKey-25-25-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-1-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-2-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-3-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-4-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-5-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-6-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-7-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-8-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-9-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-10-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-11-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-12-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-13-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-14-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-15-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-16-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-17-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-18-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-19-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-20-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-21-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-22-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-23-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-24-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-25-master-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-1-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-2-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-3-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-4-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-5-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-6-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-7-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-8-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-9-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-10-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-11-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-12-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-13-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-14-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-15-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-16-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-17-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-18-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-19-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-20-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-21-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-22-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-23-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-24-latest-chrome-mysql5.7-php7.0
-- webUIcoreUKey-25-25-latest-chrome-mysql5.7-php7.0
+- cliEncryption-master-mysql5.5-php7.1
+- cliEncryption-master-postgres9.4-php7.1
+- cliEncryption-latest-mysql5.5-php7.1
+- cliEncryption-latest-postgres9.4-php7.1
+- webUIMasterKey-master-chrome-mysql5.5-php7.1
+- webUIMasterKey-latest-chrome-mysql5.5-php7.1
+- webUIUserKeys-master-chrome-mysql5.5-php7.1
+- webUIUserKeys-latest-chrome-mysql5.5-php7.1
+- apiCoreMKey-25-1-master-mysql5.7-php7.1
+- apiCoreMKey-25-2-master-mysql5.7-php7.1
+- apiCoreMKey-25-3-master-mysql5.7-php7.1
+- apiCoreMKey-25-4-master-mysql5.7-php7.1
+- apiCoreMKey-25-5-master-mysql5.7-php7.1
+- apiCoreMKey-25-6-master-mysql5.7-php7.1
+- apiCoreMKey-25-7-master-mysql5.7-php7.1
+- apiCoreMKey-25-8-master-mysql5.7-php7.1
+- apiCoreMKey-25-9-master-mysql5.7-php7.1
+- apiCoreMKey-25-10-master-mysql5.7-php7.1
+- apiCoreMKey-25-11-master-mysql5.7-php7.1
+- apiCoreMKey-25-12-master-mysql5.7-php7.1
+- apiCoreMKey-25-13-master-mysql5.7-php7.1
+- apiCoreMKey-25-14-master-mysql5.7-php7.1
+- apiCoreMKey-25-15-master-mysql5.7-php7.1
+- apiCoreMKey-25-16-master-mysql5.7-php7.1
+- apiCoreMKey-25-17-master-mysql5.7-php7.1
+- apiCoreMKey-25-18-master-mysql5.7-php7.1
+- apiCoreMKey-25-19-master-mysql5.7-php7.1
+- apiCoreMKey-25-20-master-mysql5.7-php7.1
+- apiCoreMKey-25-21-master-mysql5.7-php7.1
+- apiCoreMKey-25-22-master-mysql5.7-php7.1
+- apiCoreMKey-25-23-master-mysql5.7-php7.1
+- apiCoreMKey-25-24-master-mysql5.7-php7.1
+- apiCoreMKey-25-25-master-mysql5.7-php7.1
+- apiCoreMKey-25-1-latest-mysql5.7-php7.1
+- apiCoreMKey-25-2-latest-mysql5.7-php7.1
+- apiCoreMKey-25-3-latest-mysql5.7-php7.1
+- apiCoreMKey-25-4-latest-mysql5.7-php7.1
+- apiCoreMKey-25-5-latest-mysql5.7-php7.1
+- apiCoreMKey-25-6-latest-mysql5.7-php7.1
+- apiCoreMKey-25-7-latest-mysql5.7-php7.1
+- apiCoreMKey-25-8-latest-mysql5.7-php7.1
+- apiCoreMKey-25-9-latest-mysql5.7-php7.1
+- apiCoreMKey-25-10-latest-mysql5.7-php7.1
+- apiCoreMKey-25-11-latest-mysql5.7-php7.1
+- apiCoreMKey-25-12-latest-mysql5.7-php7.1
+- apiCoreMKey-25-13-latest-mysql5.7-php7.1
+- apiCoreMKey-25-14-latest-mysql5.7-php7.1
+- apiCoreMKey-25-15-latest-mysql5.7-php7.1
+- apiCoreMKey-25-16-latest-mysql5.7-php7.1
+- apiCoreMKey-25-17-latest-mysql5.7-php7.1
+- apiCoreMKey-25-18-latest-mysql5.7-php7.1
+- apiCoreMKey-25-19-latest-mysql5.7-php7.1
+- apiCoreMKey-25-20-latest-mysql5.7-php7.1
+- apiCoreMKey-25-21-latest-mysql5.7-php7.1
+- apiCoreMKey-25-22-latest-mysql5.7-php7.1
+- apiCoreMKey-25-23-latest-mysql5.7-php7.1
+- apiCoreMKey-25-24-latest-mysql5.7-php7.1
+- apiCoreMKey-25-25-latest-mysql5.7-php7.1
+- apiCoreUKey-25-1-master-mysql5.7-php7.1
+- apiCoreUKey-25-2-master-mysql5.7-php7.1
+- apiCoreUKey-25-3-master-mysql5.7-php7.1
+- apiCoreUKey-25-4-master-mysql5.7-php7.1
+- apiCoreUKey-25-5-master-mysql5.7-php7.1
+- apiCoreUKey-25-6-master-mysql5.7-php7.1
+- apiCoreUKey-25-7-master-mysql5.7-php7.1
+- apiCoreUKey-25-8-master-mysql5.7-php7.1
+- apiCoreUKey-25-9-master-mysql5.7-php7.1
+- apiCoreUKey-25-10-master-mysql5.7-php7.1
+- apiCoreUKey-25-11-master-mysql5.7-php7.1
+- apiCoreUKey-25-12-master-mysql5.7-php7.1
+- apiCoreUKey-25-13-master-mysql5.7-php7.1
+- apiCoreUKey-25-14-master-mysql5.7-php7.1
+- apiCoreUKey-25-15-master-mysql5.7-php7.1
+- apiCoreUKey-25-16-master-mysql5.7-php7.1
+- apiCoreUKey-25-17-master-mysql5.7-php7.1
+- apiCoreUKey-25-18-master-mysql5.7-php7.1
+- apiCoreUKey-25-19-master-mysql5.7-php7.1
+- apiCoreUKey-25-20-master-mysql5.7-php7.1
+- apiCoreUKey-25-21-master-mysql5.7-php7.1
+- apiCoreUKey-25-22-master-mysql5.7-php7.1
+- apiCoreUKey-25-23-master-mysql5.7-php7.1
+- apiCoreUKey-25-24-master-mysql5.7-php7.1
+- apiCoreUKey-25-25-master-mysql5.7-php7.1
+- apiCoreUKey-25-1-latest-mysql5.7-php7.1
+- apiCoreUKey-25-2-latest-mysql5.7-php7.1
+- apiCoreUKey-25-3-latest-mysql5.7-php7.1
+- apiCoreUKey-25-4-latest-mysql5.7-php7.1
+- apiCoreUKey-25-5-latest-mysql5.7-php7.1
+- apiCoreUKey-25-6-latest-mysql5.7-php7.1
+- apiCoreUKey-25-7-latest-mysql5.7-php7.1
+- apiCoreUKey-25-8-latest-mysql5.7-php7.1
+- apiCoreUKey-25-9-latest-mysql5.7-php7.1
+- apiCoreUKey-25-10-latest-mysql5.7-php7.1
+- apiCoreUKey-25-11-latest-mysql5.7-php7.1
+- apiCoreUKey-25-12-latest-mysql5.7-php7.1
+- apiCoreUKey-25-13-latest-mysql5.7-php7.1
+- apiCoreUKey-25-14-latest-mysql5.7-php7.1
+- apiCoreUKey-25-15-latest-mysql5.7-php7.1
+- apiCoreUKey-25-16-latest-mysql5.7-php7.1
+- apiCoreUKey-25-17-latest-mysql5.7-php7.1
+- apiCoreUKey-25-18-latest-mysql5.7-php7.1
+- apiCoreUKey-25-19-latest-mysql5.7-php7.1
+- apiCoreUKey-25-20-latest-mysql5.7-php7.1
+- apiCoreUKey-25-21-latest-mysql5.7-php7.1
+- apiCoreUKey-25-22-latest-mysql5.7-php7.1
+- apiCoreUKey-25-23-latest-mysql5.7-php7.1
+- apiCoreUKey-25-24-latest-mysql5.7-php7.1
+- apiCoreUKey-25-25-latest-mysql5.7-php7.1
+- webUIcoreMKey-25-1-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-2-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-3-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-4-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-5-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-6-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-7-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-8-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-9-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-10-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-11-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-12-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-13-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-14-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-15-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-16-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-17-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-18-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-19-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-20-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-21-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-22-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-23-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-24-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-25-master-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-1-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-2-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-3-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-4-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-5-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-6-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-7-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-8-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-9-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-10-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-11-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-12-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-13-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-14-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-15-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-16-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-17-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-18-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-19-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-20-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-21-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-22-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-23-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-24-latest-chrome-mysql5.7-php7.1
+- webUIcoreMKey-25-25-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-1-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-2-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-3-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-4-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-5-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-6-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-7-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-8-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-9-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-10-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-11-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-12-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-13-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-14-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-15-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-16-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-17-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-18-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-19-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-20-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-21-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-22-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-23-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-24-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-25-master-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-1-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-2-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-3-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-4-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-5-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-6-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-7-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-8-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-9-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-10-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-11-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-12-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-13-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-14-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-15-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-16-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-17-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-18-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-19-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-20-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-21-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-22-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-23-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-24-latest-chrome-mysql5.7-php7.1
+- webUIcoreUKey-25-25-latest-chrome-mysql5.7-php7.1
 
 ...


### PR DESCRIPTION
Because core has dropped PHP 7.0 support https://github.com/owncloud/core/pull/36290