### PR TITLE
[Tests-Only] Return null if keyPair is null

### DIFF
--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -287,6 +287,7 @@ class UserHooks implements IHook {
 				$keyPair = $this->crypt->createKeyPair("oc:uid:$user");
 
 				if ($keyPair === null) {
+					$this->logger->error('Encryption Could not update users encryption password');
 					return null;
 				}
 

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -219,7 +219,7 @@ class UserHooks implements IHook {
 	 * If the password can't be changed within ownCloud, than update the key password in advance.
 	 *
 	 * @param array $params : uid, password
-	 * @return boolean|null
+	 * @return void
 	 */
 	public function preSetPassphrase($params) {
 		if (App::isEnabled('encryption')) {
@@ -286,6 +286,10 @@ class UserHooks implements IHook {
 
 				$keyPair = $this->crypt->createKeyPair("oc:uid:$user");
 
+				if ($keyPair === null) {
+					return null;
+				}
+
 				// Save public key
 				$this->keyManager->setPublicKey($user, $keyPair['publicKey']);
 
@@ -300,6 +304,7 @@ class UserHooks implements IHook {
 					}
 				} else {
 					$this->logger->error('Encryption Could not update users encryption password');
+					return null;
 				}
 			}
 		}

--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -191,7 +191,7 @@ class UserHooksTest extends TestCase {
 			->method('getPrivateKey')
 			->willReturnOnConsecutiveCalls(true, false);
 
-		$this->cryptMock->expects($this->exactly(4))
+		$this->cryptMock->expects($this->exactly(1))
 			->method('encryptPrivateKey')
 			->willReturn(true);
 
@@ -199,7 +199,7 @@ class UserHooksTest extends TestCase {
 			->method('generateHeader')
 			->willReturn(Crypt::HEADER_START . ':Cipher:test:' . Crypt::HEADER_END);
 
-		$this->keyManagerMock->expects($this->exactly(4))
+		$this->keyManagerMock->expects($this->exactly(1))
 			->method('setPrivateKey')
 			->willReturnCallback(function ($user, $key) {
 				$header = \substr($key, 0, \strlen(Crypt::HEADER_START));
@@ -254,10 +254,10 @@ class UserHooksTest extends TestCase {
 		$this->cryptMock->expects($this->once())
 			->method('createKeyPair');
 
-		$this->keyManagerMock->expects($this->once())
+		$this->keyManagerMock->expects($this->exactly(0))
 			->method('setPrivateKey');
 
-		$this->recoveryMock->expects($this->once())
+		$this->recoveryMock->expects($this->exactly(0))
 			->method('recoverUsersFiles')
 			->with('password', 'testUser');
 

--- a/tests/unit/Hooks/UserHooksTest.php
+++ b/tests/unit/Hooks/UserHooksTest.php
@@ -299,8 +299,8 @@ class UserHooksTest extends TestCase {
 			->method('setPrivateKey')
 			->willReturn(true);
 
-		//No logger error should appear
-		$logger->expects($this->never())
+		//logger error should appear when keypair is null
+		$logger->expects($this->exactly(1))
 			->method('error');
 
 		$this->assertNull($userHooks->setPassphrase($this->params));


### PR DESCRIPTION
##### Linked Issue:
Fixes https://github.com/owncloud/encryption/issues/193

##### Description
Return null if keyPair inside `setPassphrase` method from `UserHooks`