### PR TITLE
Bump phpstan to 0.12

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.10.2"
+        "phpstan/phpstan": "^0.12"
     }
 }


### PR DESCRIPTION
without actually enabling it.

Issue https://github.com/owncloud/QA/issues/642

Note: PR #189 attempts to enable `phpstan` here, but that is taking more effort to sort out the things that `phpstan` finds.