### PR TITLE
Adjust phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,8 @@
 parameters:
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   inferPrivatePropertyTypeFromConstructor: true
   excludes_analyse:
-    - %currentWorkingDirectory%/appinfo/Migrations/*.php
     - %currentWorkingDirectory%/appinfo/routes.php
   ignoreErrors:
 


### PR DESCRIPTION
- adjust `phpstan.neon` for new `bootstrapFiles` section.
- remove Migrations from `excludes_analyse` section, they can be analyzed OK now