### PR TITLE
[Tests-Only] Remove unneeded phpstan-ignore-line for openssl_pkey_export

### DIFF
--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -116,7 +116,7 @@ class Crypt {
 				$log->error('Encryption library openssl_pkey_new() fails: ' . \openssl_error_string(),
 					['app' => 'encryption']);
 			}
-		} elseif (\openssl_pkey_export($res, /** @phpstan-ignore-line */
+		} elseif (\openssl_pkey_export($res,
 			$privateKey,
 			null,
 			$this->getOpenSSLConfig())) {


### PR DESCRIPTION
https://github.com/phpstan/phpstan/releases/tag/0.12.31 fixed its definition of the signature of `openssl_pkey_export` PR https://github.com/phpstan/phpstan-src/pull/256

`phpstan` started reporting:
https://drone.owncloud.com/owncloud/encryption/1324/4/4
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ --------------------------------------------- 
  Line   lib/Crypto/Crypt.php                         
 ------ --------------------------------------------- 
  119    No error to ignore is reported on line 119.  
 ------ --------------------------------------------- 

 [ERROR] Found 1 error 
```

Remove `phpstan-ignore-line`