### PR TITLE
fix: avoid mac collisions

### DIFF
--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -185,7 +185,7 @@ class Crypt {
 			$this->getCipher());
 
 		// Create a signature based on the key as well as the current version
-		$sig = $this->createSignature($encryptedContent, $passPhrase . $version . $position);
+		$sig = $this->createSignature($encryptedContent, $passPhrase . $version . "-" . $position);
 
 		// combine content to encrypt the IV identifier and actual IV
 		$catFile = $this->concatIV($encryptedContent, $iv);
@@ -454,7 +454,12 @@ class Crypt {
 		$catFile = $this->splitMetaData($keyFileContents, $cipher);
 
 		if ($catFile['signature'] !== false) {
-			$this->checkSignature($catFile['encrypted'], $passPhrase . $version . $position, $catFile['signature']);
+			try {
+				$this->checkSignature($catFile['encrypted'], $passPhrase . $version . "-" . $position, $catFile['signature']);
+			} catch (HintException $e) {
+				// Check legacy format...
+				$this->checkSignature($catFile['encrypted'], $passPhrase . $version . $position, $catFile['signature']);
+			}
 		}
 
 		return $this->decrypt($catFile['encrypted'],


### PR DESCRIPTION
In certain constellations, e.g. file version 1 and block position 10 or file version 11 and block position 0, the mac could collide. To prevent this I introduce a seperator between the file version and the block position.
