### PR TITLE
allow binary encoding for written files to reduce file size

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -75,6 +75,32 @@ config = {
 				}
 			],
 		},
+		'api-masterkey': {
+			'suites': {
+				'apiEncryption': 'apiMasterKeys',
+			},
+			'databases': [
+				'mysql:5.5',
+				'postgres:9.4',
+			],
+			'servers': [
+				'daily-master-qa',
+				'latest'
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.2',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'php occ encryption:enable',
+						'php occ encryption:select-encryption-type masterkey --yes',
+						'php occ config:list',
+					]
+				}
+			],
+		},
 		'webUI-masterkey': {
 			'suites': {
 				'webUIMasterKeyType': 'webUIMasterKey',
@@ -96,6 +122,32 @@ config = {
 						'cd /var/www/owncloud/server',
 						'php occ encryption:enable',
 						'php occ encryption:select-encryption-type masterkey --yes',
+						'php occ config:list',
+					]
+				}
+			],
+		},
+		'api-userkeys': {
+			'suites': {
+				'apiEncryption': 'apiUserKeys',
+			},
+			'databases': [
+				'mysql:5.5',
+				'postgres:9.4',
+			],
+			'servers': [
+				'daily-master-qa',
+				'latest'
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.2',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'php occ encryption:enable',
+						'php occ encryption:select-encryption-type user-keys --yes',
 						'php occ config:list',
 					]
 				}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1325,6 +1325,452 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: apiMasterKeys-master-mysql5.5-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiMasterKeys-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiMasterKeys-latest-mysql5.5-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiMasterKeys-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type masterkey --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
 name: webUIMasterKey-master-chrome-mysql5.5-php7.2
 
 platform:
@@ -1555,6 +2001,452 @@ services:
 - name: email
   pull: always
   image: mailhog/mailhog
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiUserKeys-master-mysql5.5-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type user-keys --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiUserKeys-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type user-keys --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiUserKeys-latest-mysql5.5-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type user-keys --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.2
+- coding-standard-php7.3
+- coding-standard-php7.4
+- phpstan-php7.2
+
+---
+kind: pipeline
+type: docker
+name: apiUserKeys-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/encryption
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/encryption
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/encryption /var/www/owncloud/server/apps/
+
+- name: setup-server-encryption
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e encryption
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ encryption:enable
+  - php occ encryption:select-encryption-type user-keys --yes
+  - php occ config:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - wait-for-it -t 600 server:80
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.4
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiEncryption
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
 
 - name: server
   pull: always
@@ -40163,8 +41055,16 @@ depends_on:
 - cliEncryption-master-postgres9.4-php7.2
 - cliEncryption-latest-mysql5.5-php7.2
 - cliEncryption-latest-postgres9.4-php7.2
+- apiMasterKeys-master-mysql5.5-php7.2
+- apiMasterKeys-master-postgres9.4-php7.2
+- apiMasterKeys-latest-mysql5.5-php7.2
+- apiMasterKeys-latest-postgres9.4-php7.2
 - webUIMasterKey-master-chrome-mysql5.5-php7.2
 - webUIMasterKey-latest-chrome-mysql5.5-php7.2
+- apiUserKeys-master-mysql5.5-php7.2
+- apiUserKeys-master-postgres9.4-php7.2
+- apiUserKeys-latest-mysql5.5-php7.2
+- apiUserKeys-latest-postgres9.4-php7.2
 - webUIUserKeys-master-chrome-mysql5.5-php7.2
 - webUIUserKeys-latest-chrome-mysql5.5-php7.2
 - apiCoreMKey-27-1-master-mysql5.7-php7.2

--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -109,10 +109,7 @@ class Crypt {
 		$this->config = $config;
 		$this->l = $l;
 		$this->supportedKeyFormats = ['hash', 'password'];
-		$this->useLegacyEncoding = $this->config->getSystemValue('encryption.use_legacy_encoding', false);
-		if ($this->useLegacyEncoding !== true) {
-			$this->useLegacyEncoding = false;
-		}
+		$this->useLegacyEncoding = $this->config->getSystemValue('encryption.use_legacy_encoding', false) === true;
 	}
 
 	/**

--- a/lib/Crypto/CryptHSM.php
+++ b/lib/Crypto/CryptHSM.php
@@ -168,7 +168,7 @@ class CryptHSM extends Crypt {
 
 			// now decode the file.
 			// version and position are 0 because we always use fresh random data as passphrase
-			$decryptedContent = $this->symmetricDecryptFileContent($encKeyFile, $decryptedKey, self::DEFAULT_CIPHER, 0, 0);
+			$decryptedContent = $this->symmetricDecryptFileContent($encKeyFile, $decryptedKey, self::DEFAULT_CIPHER, 0, 0, true);
 
 			return $decryptedContent;
 		} catch (ServerException $e) {

--- a/lib/Crypto/Encryption.php
+++ b/lib/Crypto/Encryption.php
@@ -94,10 +94,17 @@ class Encryption implements IEncryptionModule {
 	private $decryptAll;
 
 	/** @var int unencrypted block size if block contains signature */
-	private $unencryptedBlockSizeSigned = 6072;
+	private $unencryptedBlockSizeSigned = 8096;
 
-	/** @var int unencrypted block size */
-	private $unencryptedBlockSize = 6126;
+	/** @var int signature size */
+	private $signatureSize = 54;
+
+	/**
+	 * @var boolean $useLegacyEncoding
+	 * In write operation, it is equal to crypt->useLegacyEncoding(),
+	 * In read operation, it is false if header contains "encoding:binary" otherwise true.
+	 */
+	private $useLegacyEncoding = false;
 
 	/** @var int Current version of the file */
 	private $version = 0;
@@ -174,6 +181,11 @@ class Encryption implements IEncryptionModule {
 		$this->user = $user;
 		$this->isWriteOperation = false;
 		$this->writeCache = '';
+		$this->useLegacyEncoding = true;
+
+		if (isset($header['encoding'])) {
+			$this->useLegacyEncoding = $header['encoding'] !== Crypt::DEFAULT_ENCODING_FORMAT;
+		}
 
 		if ($this->session->decryptAllModeActivated()) {
 			$encryptedFileKey = $this->keyManager->getEncryptedFileKey($this->path);
@@ -215,6 +227,7 @@ class Encryption implements IEncryptionModule {
 
 		if ($this->isWriteOperation) {
 			$this->cipher = $this->crypt->getCipher();
+			$this->useLegacyEncoding = $this->crypt->useLegacyEncoding();
 		} elseif (isset($header['cipher'])) {
 			$this->cipher = $header['cipher'];
 		} else {
@@ -223,7 +236,11 @@ class Encryption implements IEncryptionModule {
 			$this->cipher = $this->crypt->getLegacyCipher();
 		}
 
-		return ['cipher' => $this->cipher, 'signed' => 'true'];
+		$return = ['cipher' => $this->cipher, 'signed' => 'true'];
+		if ($this->useLegacyEncoding !== true) {
+			$return['encoding'] = $this->crypt::DEFAULT_ENCODING_FORMAT;
+		}
+		return $return;
 	}
 
 	/**
@@ -310,8 +327,8 @@ class Encryption implements IEncryptionModule {
 			$remainingLength = \strlen($data);
 
 			// If data remaining to be written is less than the
-			// size of 1 6126 byte block
-			if ($remainingLength < $this->unencryptedBlockSizeSigned) {
+			// size of 1 unencrypted block size byte block
+			if ($remainingLength < $this->getUnencryptedBlockSize(true)) {
 
 				// Set writeCache to contents of $data
 				// The writeCache will be carried over to the
@@ -328,14 +345,14 @@ class Encryption implements IEncryptionModule {
 			} else {
 
 				// Read the chunk from the start of $data
-				$chunk = \substr($data, 0, $this->unencryptedBlockSizeSigned);
+				$chunk = \substr($data, 0, $this->getUnencryptedBlockSize(true));
 
 				$encrypted .= $this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey, $this->version + 1, $position);
 
 				// Remove the chunk we just processed from
 				// $data, leaving only unprocessed data in $data
 				// var, for handling on the next round
-				$data = \substr($data, $this->unencryptedBlockSizeSigned);
+				$data = \substr($data, $this->getUnencryptedBlockSize(true));
 			}
 		}
 
@@ -359,7 +376,7 @@ class Encryption implements IEncryptionModule {
 			throw new DecryptionFailedException($msg, $hint);
 		}
 
-		return $this->crypt->symmetricDecryptFileContent($data, $this->fileKey, $this->cipher, $this->version, $position);
+		return $this->crypt->symmetricDecryptFileContent($data, $this->fileKey, $this->cipher, $this->version, $position, !$this->useLegacyEncoding);
 	}
 
 	/**
@@ -451,11 +468,16 @@ class Encryption implements IEncryptionModule {
 	 * @return int
 	 */
 	public function getUnencryptedBlockSize($signed = false) {
+		$blockSize = $this->unencryptedBlockSizeSigned;
+		if ($this->useLegacyEncoding) {
+			// Legacy base64 encoding reduces unencrypted block size to 3/4
+			$blockSize = ($blockSize/4) * 3;
+		}
 		if ($signed === false) {
-			return $this->unencryptedBlockSize;
+			$blockSize = $blockSize + $this->signatureSize;
 		}
 
-		return $this->unencryptedBlockSizeSigned;
+		return $blockSize;
 	}
 
 	/**

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -16,6 +16,15 @@ default:
             ocPath: apps/testing/api/v1/occ
         - OccContext:
 
+    apiEncryption:
+      paths:
+        - '%paths.base%/../features/apiEncryption'
+      contexts:
+        - EncryptionContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - TrashbinContext:
+
     webUIUserKeysType:
       paths:
         - '%paths.base%/../features/webUIUserKeysType'

--- a/tests/acceptance/features/apiEncryption/encoding.feature
+++ b/tests/acceptance/features/apiEncryption/encoding.feature
@@ -1,0 +1,102 @@
+@api
+Feature: encrypt files with legacy and default(new) encoding
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario: encrypted file with default encoding
+    Given user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: encrypted file with legacy encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: Download encrypted files with different encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some new data" to "/textfile2.txt"
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+    And the content of file "/textfile2.txt" for user "Alice" should be "some new data"
+
+  Scenario: overwrite file with legacy encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some new data" to "/textfile1.txt"
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some new data"
+
+  Scenario: overwrite file with default encoding by legacy encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some new data" to "/textfile1.txt"
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some new data"
+
+  Scenario: share file with legacy encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    Then the content of file "/textfile1.txt" for user "Brian" should be "some data"
+
+  Scenario: share file with default encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    Then the content of file "/textfile1.txt" for user "Brian" should be "some data"
+
+  Scenario: Restore a file with legacy encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has deleted file "/textfile1.txt"
+    When user "Alice" restores the folder with original path "/textfile1.txt" using the trashbin API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: Restore a file with default encoding
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has deleted file "/textfile1.txt"
+    When user "Alice" restores the folder with original path "/textfile1.txt" using the trashbin API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: Restore a file with legacy encoding after encoding is changed
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has deleted file "/textfile1.txt"
+    When the administrator adds system config key "encryption.use_legacy_encoding" with value "false" and type boolean using the occ command
+    And user "Alice" restores the folder with original path "/textfile1.txt" using the trashbin API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: Restore a file with default encoding after encoding is changed
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has deleted file "/textfile1.txt"
+    When the administrator adds system config key "encryption.use_legacy_encoding" with value "true" and type boolean using the occ command
+    And user "Alice" restores the folder with original path "/textfile1.txt" using the trashbin API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some data"
+
+  Scenario: User overwrites a shared file with legacy encoding after encoding is switched
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    And the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    Then the content of file "/textfile1.txt" for user "Brian" should be "some data"
+    When user "Brian" uploads file with content "some new data" to "/textfile1.txt" using the WebDAV API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some new data"
+    And the content of file "/textfile1.txt" for user "Brian" should be "some new data"
+
+  Scenario: User overwrites a shared file with default encoding after encoding is switched
+    Given the administrator has added system config key "encryption.use_legacy_encoding" with value "true" and type "boolean"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    And the administrator has added system config key "encryption.use_legacy_encoding" with value "false" and type "boolean"
+    Then the content of file "/textfile1.txt" for user "Brian" should be "some data"
+    When user "Brian" uploads file with content "some new data" to "/textfile1.txt" using the WebDAV API
+    Then the content of file "/textfile1.txt" for user "Alice" should be "some new data"
+    And the content of file "/textfile1.txt" for user "Brian" should be "some new data"

--- a/tests/unit/Crypto/CryptTest.php
+++ b/tests/unit/Crypto/CryptTest.php
@@ -131,9 +131,9 @@ class CryptTest extends TestCase {
 	 */
 	public function dataTestGenerateHeader() {
 		return [
-			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:HEND'],
-			['password', 'HBEGIN:cipher:AES-128-CFB:keyFormat:password:HEND'],
-			['hash', 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:HEND']
+			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:encoding:binary:HEND'],
+			['password', 'HBEGIN:cipher:AES-128-CFB:keyFormat:password:encoding:binary:HEND'],
+			['hash', 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:encoding:binary:HEND']
 		];
 	}
 
@@ -314,7 +314,7 @@ class CryptTest extends TestCase {
 	/**
 	 * test encrypt()
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function testEncrypt() {
 		$decrypted = 'content';
@@ -344,7 +344,7 @@ class CryptTest extends TestCase {
 		$result = self::invokePrivate(
 			$this->crypt,
 			'decrypt',
-			[$data['encrypted'], $data['iv'], $data['password']]);
+			[$data['encrypted'], $data['iv'], $data['password'], $this->crypt::DEFAULT_CIPHER, true]);
 
 		$this->assertSame($data['decrypted'], $result);
 	}


### PR DESCRIPTION
Fixes #210, https://github.com/owncloud/core/issues/10831
Needs https://github.com/owncloud/core/pull/38249

This PR makes binary encoding default and writes the encoding info to the file metadata. After this PR, all the newly created files will be encrypted with binary encoding.
For decryption, if no metadata presents we keep continue to decrypt these files with legacy base64 encoding, if header is present we use binary encoding to decrypt those files.

