### PR TITLE
Prevent command encryption:fix-encrypted-version from printing file binary data

### DIFF
--- a/lib/Command/FixEncryptedVersion.php
+++ b/lib/Command/FixEncryptedVersion.php
@@ -143,7 +143,9 @@ class FixEncryptedVersion extends Command {
 			 * mismatch error. Which as of now, is enough to proceed ahead to
 			 * correct the encrypted version.
 			 */
-			if ($this->view->readfilePart($path, 0, 9000) !== false) {
+			$handle = $this->view->fopen($path, 'rb');
+
+			if (\fread($handle, 9001)) {
 				$output->writeln("<info>The file $path is: OK</info>");
 			}
 			return true;

--- a/lib/Command/FixEncryptedVersion.php
+++ b/lib/Command/FixEncryptedVersion.php
@@ -145,9 +145,12 @@ class FixEncryptedVersion extends Command {
 			 */
 			$handle = $this->view->fopen($path, 'rb');
 
-			if (\fread($handle, 9001)) {
+			if (\fread($handle, 9001) !== false) {
 				$output->writeln("<info>The file $path is: OK</info>");
 			}
+
+			\fclose($handle);
+
 			return true;
 		} catch (HintException $e) {
 			\OC::$server->getLogger()->warning("Issue: " . $e->getMessage());

--- a/tests/unit/Command/FixEncryptedVersionTest.php
+++ b/tests/unit/Command/FixEncryptedVersionTest.php
@@ -133,12 +133,6 @@ The file /test_enc_version_affected_user1/files/hello.txt is: OK
 Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1", $output);
 		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
 The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
-		/**
-		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
-		 * where as the ob_get_level is found to be zero.
-		 */
-		\ob_start();
 	}
 
 	/**
@@ -207,12 +201,6 @@ Increment the encrypted version to 4
 Increment the encrypted version to 5
 The file /test_enc_version_affected_user1/files/world.txt is: OK
 Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5", $output);
-		/**
-		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
-		 * where as the ob_get_level is found to be zero.
-		 */
-		\ob_start();
 	}
 
 	/**
@@ -282,12 +270,6 @@ Decrement the encrypted version to 10
 Decrement the encrypted version to 9
 The file /test_enc_version_affected_user1/files/world.txt is: OK
 Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9", $output);
-		/**
-		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
-		 * where as the ob_get_level is found to be zero.
-		 */
-		\ob_start();
 	}
 
 	/**
@@ -305,12 +287,6 @@ Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9"
 
 		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
 The file /test_enc_version_affected_user1/files/hello.txt is: OK", $output);
-		/**
-		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
-		 * where as the ob_get_level is found to be zero.
-		 */
-		\ob_start();
 	}
 
 	/**
@@ -330,12 +306,6 @@ The file /test_enc_version_affected_user1/files/hello.txt is: OK", $output);
 The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
 		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
 The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
-		/**
-		 * We need to add ob_start at the end because if not done, it would be considered as a risky test.
-		 * The reason is outputBufferingLevel in phpunit/src/Framework/TestCase.php is found to be 1
-		 * where as the ob_get_level is found to be zero.
-		 */
-		\ob_start();
 	}
 
 	/**


### PR DESCRIPTION
While running the command  encryption:fix-encrypted-version binary data has been printed, this PR fixed this.


Before:
![image](https://user-images.githubusercontent.com/26169327/102795143-b1b81800-43ac-11eb-8297-fd5deec17e6a.png)

After:
![image](https://user-images.githubusercontent.com/26169327/102795198-c5fc1500-43ac-11eb-9709-293d5d012d42.png)


