### PR TITLE
[tests-only] Test against core unencrypted-block-size PR 38249

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1761,7 +1761,7 @@ def installCore(version, db, useBundledApp):
 		'image': 'owncloudci/core',
 		'pull': 'always',
 		'settings': {
-			'version': version,
+			'git_reference': 'unencrypted-block-size',
 			'core_path': '/var/www/owncloud/server',
 			'db_type': dbType,
 			'db_name': database,


### PR DESCRIPTION
Run CI using core branch `unencrypted-block-size` PR https://github.com/owncloud/core/pull/38249
