### PR TITLE
[tests-only] Pin behat/gherkin because of Gherkin issue 187

### DIFF
--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -262,7 +262,7 @@ class Crypt {
 		}
 
 		// Workaround for OpenSSL 0.9.8. Fallback to an old cipher that should work.
-		if (OPENSSL_VERSION_NUMBER < 0x1000101f) { /** @phpstan-ignore-line */
+		if (OPENSSL_VERSION_NUMBER < 0x1000101f) {
 			if ($cipher === 'AES-256-CTR' || $cipher === 'AES-128-CTR') {
 				$cipher = self::LEGACY_CIPHER;
 			}

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -6,6 +6,7 @@
     },
     "require": {
         "behat/behat": "^3.8",
+        "behat/gherkin": "4.6.2",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",


### PR DESCRIPTION
## Description
1) Pin the version of `Behat/Gherkin` to avoid issue https://github.com/Behat/Gherkin/issues/187
2) phpstan 0.12.69 https://github.com/phpstan/phpstan/releases/tag/0.12.69 was released yesterday. That fixed a code analysis error about `OPENSSL_VERSION_NUMBER` constant. Remove the `phpstan-ignore-line` annotation.

## Related Issue
workaround for #38338 

