### PR TITLE
Use binary encoding setting for HSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - XXXX-XX-XX
 
--
+- Use legacy-encoding setting for HSM also [#269](https://github.com/owncloud/encryption/issues/269)
 
 ## [1.5.0] - 2021-03-11
 

--- a/lib/Crypto/CryptHSM.php
+++ b/lib/Crypto/CryptHSM.php
@@ -168,7 +168,7 @@ class CryptHSM extends Crypt {
 
 			// now decode the file.
 			// version and position are 0 because we always use fresh random data as passphrase
-			$decryptedContent = $this->symmetricDecryptFileContent($encKeyFile, $decryptedKey, self::DEFAULT_CIPHER, 0, 0, true);
+			$decryptedContent = $this->symmetricDecryptFileContent($encKeyFile, $decryptedKey, self::DEFAULT_CIPHER, 0, 0, !$this->useLegacyEncoding());
 
 			return $decryptedContent;
 		} catch (ServerException $e) {


### PR DESCRIPTION
This caused issues migrating HSM instances with encryption to 10.7

Fixes #269 