### PR TITLE
Switch CI badge from travis to drone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # encryption
  :lock_with_ink_pen: server side encryption of files
  
- [![Build Status](https://travis-ci.org/owncloud/encryption.svg?branch=master)](https://travis-ci.org/owncloud/encryption)
+ [![Build Status](https://drone.owncloud.com/api/badges/owncloud/encryption/status.svg)](https://drone.owncloud.com/owncloud/encryption)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_encryption&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_encryption)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_encryption&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_encryption)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_encryption&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_encryption)


### PR DESCRIPTION
I am always confused, when the readme points to a wrong CI instance. In this case its is obviously outdated: 3 years no activity on travis -> we can safely switch.