### PR TITLE
Remove always-true encryptedFileKey var from if test

### DIFF
--- a/lib/KeyManager.php
+++ b/lib/KeyManager.php
@@ -429,7 +429,7 @@ class KeyManager {
 			$privateKey = $this->session->getPrivateKey();
 		}
 
-		if ($encryptedFileKey && $shareKey && $privateKey) {
+		if ($shareKey && $privateKey) {
 			return $this->crypt->multiKeyDecrypt(
 				$encryptedFileKey,
 				$shareKey,


### PR DESCRIPTION
Fixes #295 

`$encryptedFileKey` is always not-false at this point in the code, because there is an earlier test for if it is `empty()` which returns early.

`phpstan` worked this out, an complained. See the issue.

Remove the useless part of the `if` test.