### PR TITLE
[tests-only] [full-ci] Bump tests to phpunit9

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -19,7 +19,7 @@ config = {
     "phpunit": {
         "withCoverage": {
             "phpVersions": [
-                "7.3",
+                "7.4",
             ],
             "databases": [
                 "sqlite",
@@ -29,7 +29,7 @@ config = {
         },
         "withoutCoverage": {
             "phpVersions": [
-                "7.4",
+                "7.3",
             ],
             "databases": [
                 "sqlite",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,22 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="tests/unit/bootstrap.php"
-		 beStrictAboutOutputDuringTests="true"
-		 verbose="true"
-		 failOnRisky="true"
-		 failOnWarning="true"
-		 timeoutForSmallTests="900"
-		 timeoutForMediumTests="900"
-		 timeoutForLargeTests="900"
-		>
-	<testsuites>
-		<testsuite name='unit'>
-			<directory suffix='Test.php'>./tests/unit</directory>
-		</testsuite>
-	</testsuites>
-	<!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">./lib</directory>
-			<directory suffix=".php">./appinfo</directory>
-			<directory suffix=".php">./templates</directory>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="./tests/output/clover.xml"/>
-	</logging>
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/unit/bootstrap.php" beStrictAboutOutputDuringTests="true" verbose="true" failOnRisky="true" failOnWarning="true" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./lib</directory>
+      <directory suffix=".php">./appinfo</directory>
+      <directory suffix=".php">./templates</directory>
+    </include>
+    <report>
+      <clover outputFile="./tests/output/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">./tests/unit</directory>
+    </testsuite>
+  </testsuites>
+  <!-- filters for code coverage -->
+  <logging>
+    <!-- and this is where your report will be written -->
+  </logging>
 </phpunit>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,5 +29,5 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mysql8.0.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-sqlite.xml
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.4-mysql8.0.xml,results/clover-phpunit-php7.4-postgres9.4.xml,results/clover-phpunit-php7.4-sqlite.xml
 sonar.javascript.lcov.reportPaths=results/lcov.info

--- a/tests/unit/Command/TestEnableMasterKey.php
+++ b/tests/unit/Command/TestEnableMasterKey.php
@@ -70,15 +70,14 @@ class TestEnableMasterKey extends TestCase {
 	 * @param string $answer
 	 */
 	public function testExecute($isAlreadyEnabled, $answer) {
-		$this->config->expects($this->at(0))
+		$this->config
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('core', 'encryption_enabled', 'no')
-			->willReturn("yes");
-
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('encryption', 'userSpecificKey', '')
-			->willReturn("");
+			->withConsecutive(
+				['core', 'encryption_enabled', 'no'],
+				['encryption', 'userSpecificKey', ''],
+			)
+			->willReturnOnConsecutiveCalls("yes", "");
 
 		$this->util->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn($isAlreadyEnabled);

--- a/tests/unit/Command/TestEnableUserKey.php
+++ b/tests/unit/Command/TestEnableUserKey.php
@@ -71,15 +71,14 @@ class TestEnableUserKey extends TestCase {
 	public function testExecute($isAlreadyEnabled, $answer) {
 		$userSpecificVal = $isAlreadyEnabled ? 1 : '';
 
-		$this->config->expects($this->at(0))
+		$this->config
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('core', 'encryption_enabled', 'no')
-			->willReturn("yes");
-
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('encryption', 'userSpecificKey', '')
-			->willReturn($userSpecificVal);
+			->withConsecutive(
+				['core', 'encryption_enabled', 'no'],
+				['encryption', 'userSpecificKey', ''],
+			)
+			->willReturnOnConsecutiveCalls("yes", $userSpecificVal);
 
 		$this->util->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn(false);

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -191,15 +191,13 @@ class SettingsControllerTest extends TestCase {
 			->method('get')->with('loginname')->willReturn('testUser');
 
 		$this->userManagerMock
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('checkPassword')
-			->with('testUserUid', 'new')
-			->willReturn(false);
-		$this->userManagerMock
-			->expects($this->at(1))
-			->method('checkPassword')
-			->with('testUser', 'new')
-			->willReturn(true);
+			->withConsecutive(
+				['testUserUid', 'new'],
+				['testUser', 'new'],
+			)
+			->willReturnOnConsecutiveCalls(false, true);
 
 		$this->cryptMock
 			->expects($this->once())

--- a/tests/unit/KeyManagerTest.php
+++ b/tests/unit/KeyManagerTest.php
@@ -272,8 +272,10 @@ class KeyManagerTest extends TestCase {
 		$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn($useMasterKey);
 
-		$this->sessionMock->expects($this->at(0))->method('setStatus')
-			->with(Session::INIT_EXECUTED);
+		$this->sessionMock
+			->expects($this->exactly(2))
+			->method('setStatus')
+			->withConsecutive([Session::INIT_EXECUTED]);
 
 		$instance->expects($this->any())->method('getMasterKeyId')->willReturn('masterKeyId');
 		$instance->expects($this->any())->method('getMasterKeyPassword')->willReturn('masterKeyPassword');
@@ -388,15 +390,14 @@ class KeyManagerTest extends TestCase {
 
 		$this->invokePrivate($this->instance, 'masterKeyId', ['masterKeyId']);
 
-		$this->keyStorageMock->expects($this->at(0))
+		$this->keyStorageMock
+			->expects($this->exactly(2))
 			->method('getFileKey')
-			->with($path, 'fileKey', 'OC_DEFAULT_MODULE')
-			->willReturn(true);
-
-		$this->keyStorageMock->expects($this->at(1))
-			->method('getFileKey')
-			->with($path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE')
-			->willReturn(true);
+			->withConsecutive(
+				[$path, 'fileKey', 'OC_DEFAULT_MODULE'],
+				[$path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE'],
+			)
+			->willReturnOnConsecutiveCalls(true, true);
 
 		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')
 			->willReturn($isMasterKeyEnabled);

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -18,6 +18,6 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.5"
     }
 }


### PR DESCRIPTION
Fixes #306 

1) switch to using PHP 7.4 for PHP unit tests with coverage (there is sometimes a problem generating coverage with PHPunit9 and PHP 7.3 and something in our combinations of dependencies... - we can easily avoid that, PHP 7.3 is about to end security support anyway...)

2) Migrate `phpunit.xml` with the command:
`../../lib/composer/bin/phpunit --migrate-configuration`

3) use phpunit 9 in acceptance test dependencies. That will fix failures running core tests like:
https://drone.owncloud.com/owncloud/encryption/2104/44/16
```
Fatal error: Call to undefined method PHPUnit\Framework\Assert::assertMatchesRegularExpression() (Behat\Testwork\Call\Exception\FatalThrowableError)
```
