### PR TITLE
run tests with 10.9.1RC1 instead of master

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -55,7 +55,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "latest",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -81,7 +81,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "latest",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -106,7 +106,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "latest",
+                "10.9.1RC1",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -133,7 +133,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "latest",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -158,7 +158,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "latest",
+                "10.9.1RC1",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -215,7 +215,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "latest",
+                "10.9.1RC1",
             ],
             "runCoreTests": True,
             "runAllSuites": True,


### PR DESCRIPTION
because of https://github.com/owncloud/encryption/issues/315 some tests fail with latest, so run them with 10.9.1RC1
this PR needs to be reverted after 10.9.1 is released and updated if there is an other RC
