### PR TITLE
run webUI core tests not on latest but on 10.9.1RC1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -306,13 +306,13 @@ config = {
         },
         "webUI-core-latest-masterkey": {
             "suites": [
-                "webUIcoreMKey",
+                "webUIcoreMK",
             ],
             "databases": [
                 "mysql:8.0",
             ],
             "servers": [
-                "latest",
+                "10.9.1RC1",
             ],
             "runCoreTests": True,
             "runAllSuites": True,


### PR DESCRIPTION
same as #316 but for a last suite
this suite only runs nightly, that is why #316 did not fail