### PR TITLE
[tests-only] Test against core latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -306,13 +306,13 @@ config = {
         },
         "webUI-core-latest-masterkey": {
             "suites": [
-                "webUIcoreMK",
+                "webUIcoreMKey",
             ],
             "databases": [
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "runCoreTests": True,
             "runAllSuites": True,

--- a/.drone.star
+++ b/.drone.star
@@ -55,7 +55,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -81,7 +81,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -106,7 +106,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -133,7 +133,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "extraSetup": [
                 {
@@ -158,7 +158,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -215,7 +215,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "runCoreTests": True,
             "runAllSuites": True,
@@ -312,7 +312,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "runCoreTests": True,
             "runAllSuites": True,

--- a/.drone.star
+++ b/.drone.star
@@ -55,7 +55,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "extraSetup": [
                 {
@@ -81,7 +81,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "extraSetup": [
                 {
@@ -106,7 +106,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -133,7 +133,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "extraSetup": [
                 {
@@ -158,7 +158,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "emailNeeded": True,
             "extraSetup": [
@@ -215,7 +215,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "runCoreTests": True,
             "runAllSuites": True,


### PR DESCRIPTION
Part of issue #317 

I reverted the 3 commits from PRs #322 #318 #316 in reverse order:
```
$ git checkout -b test-against-core-latest
Switched to a new branch 'test-against-core-latest'
$ git revert 398bf2a20c4dd1a94adb5dcf097b1e30766d5674
[test-against-core-latest 211ad06] Revert "Test against 10.9.1RC2"
 1 file changed, 7 insertions(+), 7 deletions(-)
$ git revert 05d8975a18631a2d60a63691a577a2c9af3753f0
[test-against-core-latest f928a77] Revert "run webUI core tests not on latest but on 10.9.1RC1"
 1 file changed, 2 insertions(+), 2 deletions(-)
$ git revert dc59932798a0b228d9502be2a64aa136492dc952
[test-against-core-latest 408530c] Revert "run tests with 10.9.1RC1 instead of master"
 1 file changed, 6 insertions(+), 6 deletions(-)
```
