### PR TITLE
[tests-only] [full-ci] Fix PHP unit tests for GuzzleHttp

### DIFF
--- a/tests/unit/Crypto/CryptHSMTest.php
+++ b/tests/unit/Crypto/CryptHSMTest.php
@@ -25,7 +25,7 @@ use OCA\Encryption\Crypto\CryptHSM;
 use OCA\Encryption\Exceptions\MultiKeyDecryptException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
-use GuzzleHttp\Client;
+use OC\Http\Client\Client;
 use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\IL10N;


### PR DESCRIPTION
Fixes #347 

The errors reported were:
```
$ make test-php-unit NOCOVERAGE=true
php -d zend.enable_gc=0 ../../lib/composer/bin/phpunit --configuration ./phpunit.xml --testsuite unit
PHPUnit 9.5.21 #StandWithUkraine

Runtime:       PHP 7.4.30
Configuration: ./phpunit.xml
Warning:       No code coverage driver available

.......................................E..EE...................  63 / 259 ( 24%)
............................................................... 126 / 259 ( 48%)
............................................................... 189 / 259 ( 72%)
............................................................... 252 / 259 ( 97%)
.......                                                         259 / 259 (100%)

Time: 00:46.756, Memory: 40.00 MB

There were 3 errors:

1) OCA\Encryption\Tests\Crypto\CryptHSMTest::testCreateKeyPair
PHPUnit\Framework\MockObject\UnknownTypeException: Class or interface "OCP\Http\Client\Client" does not exist

/home/phil/git/owncloud/core/apps-external/encryption/tests/unit/Crypto/CryptHSMTest.php:92
phpvfscomposer:///home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit:97

2) OCA\Encryption\Tests\Crypto\CryptHSMTest::testMultiKeyDecryptExceptions with data set #1 ('encKey', 'foo', 'abcd')
PHPUnit\Framework\MockObject\UnknownTypeException: Class or interface "OCP\Http\Client\Client" does not exist

/home/phil/git/owncloud/core/apps-external/encryption/tests/unit/Crypto/CryptHSMTest.php:138
phpvfscomposer:///home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit:97

3) OCA\Encryption\Tests\Crypto\CryptHSMTest::testMultiKeyDecrypt
PHPUnit\Framework\MockObject\UnknownTypeException: Class or interface "OCP\Http\Client\Client" does not exist

/home/phil/git/owncloud/core/apps-external/encryption/tests/unit/Crypto/CryptHSMTest.php:159
phpvfscomposer:///home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit:97

ERRORS!
Tests: 259, Assertions: 742, Errors: 3.
make: *** [Makefile:83: test-php-unit] Error 2
```

The change here makes the tests pass.