### PR TITLE
Fixup makefile clean and bump composer-bin-plugin 1.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ doc_files=README.md CHANGELOG.md LICENSE
 src_dirs=appinfo css img js l10n lib templates
 all_src=$(src_dirs) $(doc_files)
 
+# composer
+composer_deps=vendor
 acceptance_test_deps=vendor-bin/behat/vendor
 
 # bin file definitions
@@ -41,10 +43,11 @@ help:
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
 
 .PHONY: clean
-clean: clean-composer-deps
+clean: clean-deps
 
-.PHONY: clean-composer-deps
-clean-composer-deps:
+.PHONY: clean-deps
+clean-deps:
+	rm -Rf ${composer_deps}
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 ##---------------------

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "c1bbee3662a2a84c6aad84b7c6daefcae29e5690"
+                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/c1bbee3662a2a84c6aad84b7c6daefcae29e5690",
-                "reference": "c1bbee3662a2a84c6aad84b7c6daefcae29e5690",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/24764700027bcd3cb072e5f8005d4a150fe714fe",
+                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe",
                 "shasum": ""
             },
             "require": {
@@ -38,7 +38,7 @@
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Bamarni\\Composer\\Bin\\Plugin"
+                "class": "Bamarni\\Composer\\Bin\\BamarniBinPlugin"
             },
             "autoload": {
                 "psr-4": {
@@ -60,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.7.0"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.0"
             },
-            "time": "2022-07-10T17:28:16+00:00"
+            "time": "2022-07-14T10:29:51+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Makefile target "clean" was not removing the vendor directory. Add that to Makefile.

Bump bamarni/composer-bin-plugin (1.7.0 => 1.8.0)

This is a change to tooling only. No actual change to the app.