### PR TITLE
use typesafe comparison

### DIFF
--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -262,7 +262,7 @@ class Crypt {
 			$iv
 		);
 
-		if (!$encryptedContent) {
+		if ($encryptedContent === false) {
 			$error = 'Encryption (symmetric) of content failed';
 			$this->logger->error(
 				$error . \openssl_error_string(),
@@ -628,11 +628,11 @@ class Crypt {
 			$iv
 		);
 
-		if ($plainContent) {
-			return $plainContent;
-		} else {
+		if ($plainContent === false) {
 			throw new DecryptionFailedException('Encryption library: Decryption (symmetric) of content failed: ' . \openssl_error_string());
 		}
+
+		return $plainContent;
 	}
 
 	/**


### PR DESCRIPTION
fixes decryption errors when a block happens to be of length 1 and be `"0"`
can be testet with a file containing just "0" or a file containing 6073 "0":
```
for f in `seq 0 6072` ; do echo -n "0" >> 6073.bin ; done
```