### PR TITLE
Handle the versions in the trashbin for the checksum verify command

### DIFF
--- a/lib/Crypto/Encryption.php
+++ b/lib/Crypto/Encryption.php
@@ -546,13 +546,16 @@ class Encryption implements IEncryptionModule {
 	 * @return string
 	 */
 	protected function getPathToRealFile($path) {
+		// By default, the "real path" is the same as the original path
 		$realPath = $path;
 		$parts = \explode('/', $path);
 		if ($parts[2] === 'files_versions') {
+			// for versions, we need to point to the actual file, not the version of the file
 			$realPath = '/' . $parts[1] . '/files/' . \implode('/', \array_slice($parts, 3));
 			$length = \strrpos($realPath, '.');
 			$realPath = \substr($realPath, 0, $length);
 		} elseif ($parts[2] === 'files_trashbin' && $parts[3] === 'versions') {
+			// if the version is in the trashbin, we need to point to the actual file inside the trashbin
 			$realPath = "/{$parts[1]}/files_trashbin/files/" . \implode('/', \array_slice($parts, 4));
 			$realPath = \preg_replace('/.v[0-9]+([^\/]*)$/', '$1', $realPath);
 		}

--- a/lib/Crypto/Encryption.php
+++ b/lib/Crypto/Encryption.php
@@ -552,6 +552,9 @@ class Encryption implements IEncryptionModule {
 			$realPath = '/' . $parts[1] . '/files/' . \implode('/', \array_slice($parts, 3));
 			$length = \strrpos($realPath, '.');
 			$realPath = \substr($realPath, 0, $length);
+		} elseif ($parts[2] === 'files_trashbin' && $parts[3] === 'versions') {
+			$realPath = "/{$parts[1]}/files_trashbin/files/" . \implode('/', \array_slice($parts, 4));
+			$realPath = \preg_replace('/.v[0-9]+([^\/]*)$/', '$1', $realPath);
 		}
 
 		return $realPath;

--- a/tests/unit/Crypto/EncryptionTest.php
+++ b/tests/unit/Crypto/EncryptionTest.php
@@ -177,6 +177,8 @@ class EncryptionTest extends TestCase {
 			['/user/files/foo.txt', '/user/files/foo.txt'],
 			['/user/files_versions/foo.txt.v543534', '/user/files/foo.txt'],
 			['/user/files_versions/foo/bar.txt.v5454', '/user/files/foo/bar.txt'],
+			['/user/files_trashbin/versions/foo.txt.v543534.d85747', '/user/files_trashbin/files/foo.txt.d85747'],
+			['/user/files_trashbin/versions/foo/bar.txt.v5454.d918273', '/user/files_trashbin/files/foo/bar.txt.d918273'],
 		];
 	}
 


### PR DESCRIPTION
`files:checksum:verify` was failing due to problems finding the right key with the versions that were in the trashbin. This was caused by a wrong computation for the right path where the key is.

Rel https://github.com/owncloud/enterprise/issues/5272