### PR TITLE
[full-ci] [tests-only] Fixed the method name changed recently in core

### DIFF
--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -117,7 +117,7 @@ class EncryptionContext implements Context {
 	):void {
 		$fileName = \ltrim($fileName, "/");
 		$filePath = "data/$username/files/$fileName";
-		$this->featureContext->readFileInServerRoot($filePath);
+		$this->featureContext->readFileInServerRootForCore($filePath);
 
 		$response = $this->featureContext->getResponse();
 		$parsedResponse = HttpRequestHelper::getResponseXml($response);
@@ -147,7 +147,7 @@ class EncryptionContext implements Context {
 	):void {
 		$fileName = \ltrim($fileName, "/");
 		$filePath = "data/$username/files/$fileName";
-		$this->featureContext->readFileInServerRoot($filePath);
+		$this->featureContext->readFileInServerRootForCore($filePath);
 
 		$response = $this->featureContext->getResponse();
 		$parsedResponse = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());


### PR DESCRIPTION
## Description
Refactored the method name from `readFileInServerRoot` to `readFileInServerRootForCore` as changed in core.

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/755
