### PR TITLE
[tests-only] Save exitcode of last occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -50,7 +50,9 @@ class EncryptionContext implements Context {
 	 * @throws \Exception
 	 */
 	public function recreateMasterKeyUsingOccCommand():void {
-		$this->featureContext->runOcc(['encryption:recreate-master-key', '-y']);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['encryption:recreate-master-key', '-y'])
+		);
 		$this->occContext->theCommandShouldHaveBeenSuccessful();
 	}
 
@@ -60,7 +62,9 @@ class EncryptionContext implements Context {
 	 * @return void
 	 */
 	public function encryptionHasBeenEnabled():void {
-		$this->featureContext->runOcc(['encryption:enable']);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['encryption:enable'])
+		);
 	}
 
 	/**
@@ -73,8 +77,10 @@ class EncryptionContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theAdministratorSetsEncryptionTypeToUsingTheOccCommand(string $encryptionType):void {
-		$this->featureContext->runOcc(
-			["encryption:select-encryption-type", $encryptionType, "-y"]
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				["encryption:select-encryption-type", $encryptionType, "-y"]
+			)
 		);
 	}
 
@@ -85,7 +91,9 @@ class EncryptionContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorEncryptsAllDataUsingTheOccCommand():void {
-		$this->featureContext->runOcc(["encryption:encrypt-all", "-y"]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(["encryption:encrypt-all", "-y"])
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
The PR https://github.com/owncloud/core/pull/40359 has implemented different method to save the exitcode of the last occ command and the local tests were failing because the exitcode was not saved.
In this PR, I have implemented the updated way to save the occ exitCode.


## Related Issue
Fixes https://github.com/owncloud/encryption/issues/369
