### PR TITLE
Drop PHP 7.3 unit testing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -57,17 +57,6 @@ config = {
                 "postgres:9.4",
             ],
         },
-        "withoutCoverage": {
-            "phpVersions": [
-                "7.3",
-            ],
-            "databases": [
-                "sqlite",
-                "mysql:8.0",
-                "postgres:9.4",
-            ],
-            "coverage": False,
-        },
     },
     "acceptance": {
         "cli-masterkey": {


### PR DESCRIPTION
core master has dropped PHP 7.3 support in PR https://github.com/owncloud/core/pull/40394 - so do not try to run PHP unit tests with 7.3 any more.