### PR TITLE
[tests-only] Update expected failure line number

### DIFF
--- a/tests/acceptance/expected-failures-cli.md
+++ b/tests/acceptance/expected-failures-cli.md
@@ -2,4 +2,5 @@
 The expected failures in this file are from features in the owncloud/core repo.
 
 #### [File remains encrypted when moved to external ownCloud storage](https://github.com/owncloud/encryption/issues/326)
--   [cliExternalStorage/filesExternalWebdavOwncloud.feature:270](https://github.com/owncloud/core/blob/master/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature#L270)
+
+-   [cliExternalStorage/filesExternalWebdavOwncloud.feature:273](https://github.com/owncloud/core/blob/master/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature#L273)


### PR DESCRIPTION
The line number was changed here recently: https://github.com/owncloud/core/pull/40435/files

Closes https://github.com/owncloud/encryption/issues/373