### PR TITLE
[tests-only] [full-ci] Run phan with PHP 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -47,6 +47,14 @@ config = {
     ],
     "codestyle": True,
     "phpstan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "javascript": False,
     "phpunit": {
         "withCoverage": {

--- a/appinfo/Migrations/Version20170913113840.php
+++ b/appinfo/Migrations/Version20170913113840.php
@@ -33,9 +33,13 @@ class Version20170913113840 implements ISimpleMigration {
 		$installedVersion = \OC::$server->getConfig()->getSystemValue('version', '0.0.0');
 
 		if (\version_compare('10.0.3', $installedVersion, '>=') === true) {
+			/** @phan-suppress-next-line PhanDeprecatedFunction */
 			$encryptionEnable = \OC::$server->getAppConfig()->getValue('encryption', 'enabled', 'yes');
+			/** @phan-suppress-next-line PhanDeprecatedFunction */
 			$coreEncryptionEnable = \OC::$server->getAppConfig()->getValue('core', 'encryption_enabled', 'yes');
+			/** @phan-suppress-next-line PhanDeprecatedFunction */
 			$userSpecificKey = \OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '');
+			/** @phan-suppress-next-line PhanDeprecatedFunction */
 			$masterKey = \OC::$server->getAppConfig()->getValue('encryption', 'useMasterKey', '');
 
 			if (($userSpecificKey === '') && ($masterKey === '') &&

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Encryption\AppInfo;
 
+/** @phan-suppress-next-line PhanUndeclaredThis */
 (new Application())->registerRoutes($this, ['routes' => [
 
 	[

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -148,6 +148,7 @@ class Application extends \OCP\AppFramework\App {
 						$server->getL10N($c->getAppName()),
 						$server->getHTTPClientService(),
 						$server->getRequest(),
+						/** @phan-suppress-next-line PhanUndeclaredMethod */
 						$server->getTimeFactory()
 					);
 				} else {

--- a/lib/Command/RecreateMasterKey.php
+++ b/lib/Command/RecreateMasterKey.php
@@ -144,7 +144,9 @@ class RecreateMasterKey extends Command {
 
 				//Reencrypt again
 				$this->appManager->enableApp('encryption');
+				/** @phan-suppress-next-line PhanDeprecatedFunction */
 				$this->appConfig->setValue('core', 'encryption_enabled', 'yes');
+				/** @phan-suppress-next-line PhanDeprecatedFunction */
 				$this->appConfig->setValue('encryption', 'useMasterKey', '1');
 
 				$output->writeln("Waiting for creating new masterkey\n");

--- a/lib/Crypto/Crypt.php
+++ b/lib/Crypto/Crypt.php
@@ -696,6 +696,7 @@ class Crypt {
 			throw new MultiKeyDecryptException('Cannot multikey decrypt empty plain content');
 		}
 
+		/** @phan-suppress-next-line PhanParamTooFewInternal */
 		if (\openssl_open($encKeyFile, $plainContent, $shareKey, $privateKey)) {
 			return $plainContent;
 		} else {
@@ -721,11 +722,13 @@ class Crypt {
 		$shareKeys = [];
 		$mappedShareKeys = [];
 
+		/** @phan-suppress-next-line PhanParamTooFewInternal */
 		if (\openssl_seal($plainContent, $sealed, $shareKeys, $keyFiles)) {
 			$i = 0;
 
 			// Ensure each shareKey is labelled with its corresponding key id
 			foreach ($keyFiles as $userId => $publicKey) {
+				/** @phan-suppress-next-line PhanTypeInvalidDimOffset */
 				$mappedShareKeys[$userId] = $shareKeys[$i];
 				$i++;
 			}

--- a/lib/Crypto/CryptHSM.php
+++ b/lib/Crypto/CryptHSM.php
@@ -123,7 +123,9 @@ class CryptHSM extends Crypt {
 		$keyPair = \json_decode($response->getBody(), true);
 
 		return [
+			/** @phan-suppress-next-line PhanTypeArraySuspiciousNullable */
 			'publicKey' => $keyPair['publicKey'],
+			/** @phan-suppress-next-line PhanTypeArraySuspiciousNullable */
 			'privateKey' => $keyPair['privateKeyId'] // returns the key id in the hsm, not the actual private key
 		];
 	}

--- a/lib/Crypto/DecryptAll.php
+++ b/lib/Crypto/DecryptAll.php
@@ -205,6 +205,7 @@ class DecryptAll {
 			}
 		}
 
+		/** @phan-suppress-next-line PhanPossiblyUndeclaredVariable */
 		$privateKey = $this->getPrivateKey($user, $password); /** @phpstan-ignore-line */
 		if ($privateKey !== false) {
 			$this->updateSession($user, $privateKey);

--- a/lib/Crypto/EncryptAll.php
+++ b/lib/Crypto/EncryptAll.php
@@ -153,6 +153,7 @@ class EncryptAll {
 		$headline = 'Encrypt all files with the ' . Encryption::DISPLAY_NAME;
 		$this->output->writeln("\n");
 		$this->output->writeln($headline);
+		/** @phan-suppress-next-line PhanParamSuspiciousOrder phan thinks this is strange code, but it is fine. */
 		$this->output->writeln(\str_pad('', \strlen($headline), '='));
 		$this->output->writeln("\n");
 

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -27,7 +27,6 @@ namespace OCA\Encryption\Hooks;
 use OC\Files\Filesystem;
 use OCP\IConfig;
 use OCP\IUserManager;
-use OCP\Util as OCUtil;
 use OCA\Encryption\Hooks\Contracts\IHook;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Crypto\Crypt;

--- a/lib/Migration.php
+++ b/lib/Migration.php
@@ -166,6 +166,7 @@ class Migration {
 			->setParameter('appid', 'files_encryption');
 		$appSettings = $oldAppValues->execute();
 
+		/** @phan-suppress-next-line PhanDeprecatedFunction */
 		while ($row = $appSettings->fetch()) {
 			// 'installed_version' gets deleted at the end of the migration process
 			if ($row['configkey'] !== 'installed_version') {
@@ -181,6 +182,7 @@ class Migration {
 			->setParameter('appid', 'files_encryption');
 		$preferenceSettings = $oldPreferences->execute();
 
+		/** @phan-suppress-next-line PhanDeprecatedFunction */
 		while ($row = $preferenceSettings->fetch()) {
 			$this->config->setUserValue($row['userid'], 'encryption', $row['configkey'], $row['configvalue']);
 			$this->config->deleteUserValue($row['userid'], 'files_encryption', $row['configkey']);
@@ -317,6 +319,7 @@ class Migration {
 	 * @return array
 	 */
 	protected function getSystemMountPoints() {
+		/** @phan-suppress-next-line PhanDeprecatedFunction */
 		return \OC\Files\External\LegacyUtil::getSystemMountPoints();
 	}
 

--- a/lib/Session.php
+++ b/lib/Session.php
@@ -60,7 +60,9 @@ class Session {
 	public function getStatus() {
 		$status = $this->session->get('encryptionInitialized');
 		if ($status === null) {
+			/** @phan-suppress-next-line PhanDeprecatedFunction */
 			if (\OC::$server->getAppConfig()->getValue('encryption', 'useMasterKey', '0') !== '0'
+				/** @phan-suppress-next-line PhanDeprecatedFunction */
 			  or \OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '') !== '') {
 				$status = self::NOT_INITIALIZED;
 			}

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.

To get `phan` passing, I suppressed most of the things it reported. They all look like OK code to me, just deprecated calls, and some code idioms that phan thinks are a bit odd.