### PR TITLE
[docs-only] Update readme to metion that encryption is supported only on oppenssl v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ With user-key encryption where only the specific user (not even the admin) can d
 `config:app:set encryption userSpecificKey --value 1/0`
 
 Set to 1 if userKey encryption is enabled
+
+
+> Note : You need openSSL version 1.1.x installed for encryption app to work. With the release change of openSSL v1.x to openSSL version 3.x in December 2021, some ciphers which were valid in version 1.x, have been retired with immediate effect. This impacts the ownCloud encryption app. Your encryption environment will break due to openSSL v3 retired (legacy) ciphers. As a result, encrypted files cant be accessed. As a temporary solution, you have to manually reenable in the openSSL v3 config the legacy ciphers. To do so, see the example in the OpenSSL 3.0 Wiki at section 6.2 Providers.


### PR DESCRIPTION
I had a hard time yesterday trying to find out why I was getting `503` with the message 
`Encryption not ready: multikeyencryption failed error:0480006C:PEM routines::no start line` and later on found out that the encryption was not supported in my ubuntu 22 as it has openssl v3. While it's mentioned here https://doc.owncloud.com/server/next/admin_manual/installation/manual_installation/manual_installation_prerequisites.html#openssl-version

I think it's relevant to mention it in the readme as well. 