### PR TITLE
Pin phpstan to 1.9.18

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.9"
+        "phpstan/phpstan": "1.9.18"
     }
 }


### PR DESCRIPTION
Related issue #385 

If we do not get any other fix quickly, we can pin phpstan to 1.9.18 (the version yesterday that passes)