### PR TITLE
[tests-only] fix: drop usage of ${}

### DIFF
--- a/tests/unit/Crypto/EncryptAllTest.php
+++ b/tests/unit/Crypto/EncryptAllTest.php
@@ -428,7 +428,7 @@ class EncryptAllTest extends TestCase {
 			->setMethods(['setupUserFS'])
 			->getMock();
 
-		$result = $this->invokePrivate($encryptAll, 'encryptFile', ["/${userName}/files/bar.txt"]);
+		$result = $this->invokePrivate($encryptAll, 'encryptFile', ["/$userName/files/bar.txt"]);
 		$this->assertTrue($result);
 
 		$view1 = new View('/');


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
