### PR TITLE
fix(ci): grant contents:read permission for translation-sync caller

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- Aligns caller permissions with the reusable workflow's explicit `permissions: contents: read` declaration added in owncloud/reusable-workflows@550eb2e
- Replaces `permissions: {}` with `permissions: contents: read` so checkout works on both public and private repos

## Test plan
- [ ] Verify the translation-sync workflow run succeeds after merge (next scheduled run or manual trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)