### PR TITLE
docs(ospo): address review feedback on community health rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-An ownCloud Classic (OC10) app that provides transparent server-side encryption of files using AES-256 keys. Once enabled in the admin settings, all newly uploaded files are encrypted at rest. The module supports master key encryption, per-user keys, recovery keys, and optional HSM (Hardware Security Module) integration for key storage.
+An ownCloud Classic (OC10) app that provides transparent server-side encryption of files using AES-256 keys. Once enabled in the admin settings, all newly uploaded files are encrypted at rest. The module supports master key encryption, recovery keys, and optional HSM (Hardware Security Module) integration for key storage. Per-user key encryption is deprecated and no longer recommended — see the [server release notes](https://doc.owncloud.com/docs/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption).
 
 ## Getting Started
 
@@ -16,7 +16,7 @@ sudo -u www-data php occ encryption:select-encryption-type masterkey
 sudo -u www-data php occ encryption:encrypt-all
 ```
 
-**Important:** Once enabled, encryption cannot be disabled. Read the documentation thoroughly before enabling. Requires OpenSSL 1.1.x (see repository notes regarding OpenSSL 3.x compatibility).
+**Important:** Read the documentation thoroughly before enabling. To reverse encryption, run `occ encryption:decrypt-all` (decrypts all files and disables encryption), followed by `occ encryption:disable`. Requires OpenSSL 1.1.x: OpenSSL 3.x retired several legacy ciphers this module depends on, which can break access to already-encrypted files. If this happens, re-enable the legacy ciphers in your OpenSSL 3.x config -- see the "Providers" section of the OpenSSL 3.0 wiki for the workaround.
 
 ## Documentation
 

--- a/agents.md
+++ b/agents.md
@@ -16,7 +16,7 @@ This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cu
 - `js/` -- Frontend JavaScript
 - `css/` -- Stylesheets
 - `templates/` -- PHP templates
-- `tests/` -- PHPUnit tests
+- `tests/` -- PHPUnit and acceptance tests
 - `l10n/` -- Translations
 - `Makefile` -- Build and test targets
 
@@ -31,8 +31,17 @@ This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cu
 # Build
 make dist
 
-# Test
+# Test (PHPUnit)
 make test-php-unit
+
+# Test (API acceptance)
+make test-acceptance-api
+
+# Test (CLI acceptance)
+make test-acceptance-cli
+
+# Test (WebUI acceptance)
+make test-acceptance-webui
 
 # Lint
 make test-php-style


### PR DESCRIPTION
## Summary

Addresses phil-davis's review comments on #425:

- `agents.md`: note `tests/` covers acceptance tests too, and list the PHPUnit/API/CLI/WebUI acceptance `make` targets individually (as suggested)
- `README.md`: drop the outdated "encryption cannot be disabled" claim — verified `occ encryption:decrypt-all` (core) explicitly disables encryption and decrypts all files, followed by `occ encryption:disable` — and restore OpenSSL 3.x legacy-cipher guidance that had been dropped
- `README.md`: stop recommending per-user key encryption — verified it's marked deprecated in `templates/settings-admin.php`, linking to the server release notes

Base is `ospo/community-health-v2` (not `master`) so merging this lands the fixes directly on #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)